### PR TITLE
fixes #14 Remove unnecessary branch name normalization

### DIFF
--- a/src/branch-name-utils.js
+++ b/src/branch-name-utils.js
@@ -1,0 +1,68 @@
+const { MB_BRANCH_FORWARD_PREFIX, MB_BRANCH_FAILED_PREFIX } = require('./constants')
+
+/**
+ * Utilities for parsing merge-bot branch names to extract metadata.
+ * Branch name formats:
+ * - merge-forward: merge-forward-pr-{prNumber}-{targetBranch}
+ * - merge-conflicts: merge-conflicts-{issueNumber}-pr-{prNumber}-{source}-to-{target}
+ */
+
+/**
+ * Shared helper to extract PR number from merge-bot branch names.
+ * Both merge-forward and merge-conflicts branches use -pr-{prNumber}- format.
+ *
+ * @param {string} branchName - The branch name to parse
+ * @returns {string|null} The PR number, or null if no match
+ */
+function extractPRNumber(branchName) {
+	const match = branchName.match(/-pr-(\d+)-/)
+	return match ? match[1] : null
+}
+
+/**
+ * Extracts the PR number from a merge-forward branch name.
+ * Format: merge-forward-pr-{prNumber}-{targetBranch}
+ * Example: merge-forward-pr-12345-release-5.8.0 -> '12345'
+ *
+ * @param {string} branchName - The branch name to parse
+ * @returns {string|null} The PR number, or null if not a merge-forward branch
+ */
+function extractPRFromMergeForward(branchName) {
+	if (!branchName.startsWith(MB_BRANCH_FORWARD_PREFIX)) {
+		return null
+	}
+	return extractPRNumber(branchName)
+}
+
+/**
+ * Extracts the PR number from a merge-conflicts branch name.
+ * Format: merge-conflicts-{issueNumber}-pr-{prNumber}-{source}-to-{target}
+ * Example: merge-conflicts-68586-pr-12345-release-5.8.0-to-main -> '12345'
+ *
+ * @param {string} branchName - The branch name to parse
+ * @returns {string|null} The PR number, or null if not a merge-conflicts branch
+ */
+function extractPRFromMergeConflicts(branchName) {
+	if (!branchName.startsWith(MB_BRANCH_FAILED_PREFIX)) {
+		return null
+	}
+	return extractPRNumber(branchName)
+}
+
+/**
+ * Extracts the target branch name from a merge-forward branch.
+ * Format: merge-forward-pr-{prNumber}-{targetBranch}
+ * Example: merge-forward-pr-123-release-5.8.0 -> 'release-5.8.0'
+ *
+ * @param {string} branchName - The merge-forward branch name
+ * @returns {string} The target branch name
+ */
+function extractTargetFromMergeForward(branchName) {
+	return branchName.replace(new RegExp(`^${MB_BRANCH_FORWARD_PREFIX}\\d+-`), '')
+}
+
+module.exports = {
+	extractPRFromMergeForward,
+	extractPRFromMergeConflicts,
+	extractTargetFromMergeForward
+}

--- a/test/auto-merge-action-test.js
+++ b/test/auto-merge-action-test.js
@@ -84,7 +84,7 @@ tap.test('createMergeConflictsBranchName encodes issue, PR, source and target', 
 	t.test('handles standard branch names', async t => {
 		const action = new TestAutoMerger({ prNumber: 123 })
 		const actual = action.createMergeConflictsBranchName('68586', 'release-5.8.0', 'main')
-		t.equal('merge-conflicts-68586-pr-123-release-5-8-0-to-main', actual)
+		t.equal('merge-conflicts-68586-pr-123-release-5.8.0-to-main', actual)
 	})
 
 	t.test('handles branch names without dots', async t => {
@@ -96,7 +96,7 @@ tap.test('createMergeConflictsBranchName encodes issue, PR, source and target', 
 	t.test('handles multiple dots in version numbers', async t => {
 		const action = new TestAutoMerger({ prNumber: 789 })
 		const actual = action.createMergeConflictsBranchName('68590', 'release-5.7.2', 'release-5.8.0')
-		t.equal('merge-conflicts-68590-pr-789-release-5-7-2-to-release-5-8-0', actual)
+		t.equal('merge-conflicts-68590-pr-789-release-5.7.2-to-release-5.8.0', actual)
 	})
 })
 
@@ -104,7 +104,7 @@ tap.test('createMergeForwardBranchName creates proper branch names', async t => 
 	t.test('handles standard branch names', async t => {
 		const action = new TestAutoMerger({ prNumber: 123 })
 		const actual = action.createMergeForwardBranchName('release-5.8.0')
-		t.equal('merge-forward-pr-123-release-5-8-0', actual)
+		t.equal('merge-forward-pr-123-release-5.8.0', actual)
 	})
 
 	t.test('handles branch names without dots', async t => {
@@ -116,7 +116,7 @@ tap.test('createMergeForwardBranchName creates proper branch names', async t => 
 	t.test('handles multiple dots in version numbers', async t => {
 		const action = new TestAutoMerger({ prNumber: 789 })
 		const actual = action.createMergeForwardBranchName('release-5.7.2')
-		t.equal('merge-forward-pr-789-release-5-7-2', actual)
+		t.equal('merge-forward-pr-789-release-5.7.2', actual)
 	})
 })
 
@@ -186,15 +186,15 @@ tap.test('executeMerges', async t => {
 		const shell = createMockShell(core, createGitShellBehavior({
 			mergeForwardBranches: {
 				'12345': [
-					{ branch: 'release-5-7-1', sha: 'abc123' },
-					{ branch: 'release-5-7-2', sha: 'def456' },
-					{ branch: 'release-5-8-0', sha: 'ghi789' }
+				{ branch: 'release-5.7.1', sha: 'abc123' },
+				{ branch: 'release-5.7.2', sha: 'def456' },
+				{ branch: 'release-5.8.0', sha: 'ghi789' }
 				]
 			},
 			revParse: {
-				'origin/merge-forward-pr-12345-release-5-7-1': 'commit-sha-5-7-1',
-				'origin/merge-forward-pr-12345-release-5-7-2': 'commit-sha-5-7-2',
-				'origin/merge-forward-pr-12345-release-5-8-0': 'commit-sha-5-8-0'
+				'origin/merge-forward-pr-12345-release-5.7.1': 'commit-sha-5-7-1',
+				'origin/merge-forward-pr-12345-release-5.7.2': 'commit-sha-5-7-2',
+				'origin/merge-forward-pr-12345-release-5.8.0': 'commit-sha-5-8-0'
 			}
 		}))
 
@@ -208,8 +208,8 @@ tap.test('executeMerges', async t => {
 
 		const action = new TestAction({
 			prNumber: 12345,
-			prBranch: 'merge-conflicts-67890-release-5-7-2-to-release-5-8-0',
-			baseBranch: 'merge-forward-pr-12345-release-5-8-0',
+			prBranch: 'merge-conflicts-67890-release-5.7.2-to-release-5.8.0',
+			baseBranch: 'merge-forward-pr-12345-release-5.8.0',
 			config: {
 				mergeTargets: ['release-5.7.1', 'release-5.7.2', 'release-5.8.0', 'main']
 			},
@@ -240,10 +240,10 @@ tap.test('executeMerges', async t => {
 
 		const shell = createMockShell(core, createGitShellBehavior({
 			mergeForwardBranches: {
-				'12345': [{ branch: 'release-5-8', sha: 'abc123' }]
+				'12345': [{ branch: 'release-5.8', sha: 'abc123' }]
 			},
 			revParse: {
-				'origin/merge-forward-pr-12345-release-5-8': 'commit-sha-release-5-8'
+				'origin/merge-forward-pr-12345-release-5.8': 'commit-sha-release-5.8'
 			}
 		}))
 
@@ -273,7 +273,7 @@ tap.test('executeMerges', async t => {
 		t.equal(result, true, 'should return true when all merges succeed')
 		t.ok(gitCalls.filter(c => c === 'checkout:release-5.8').length >= 2,
 			'should checkout release-5.8 for merging AND for updating')
-		t.ok(gitCalls.find(c => c.includes('merge:commit-sha-release-5-8:--ff-only')),
+		t.ok(gitCalls.find(c => c.includes('merge:commit-sha-release-5.8:--ff-only')),
 			'should fast-forward release-5.8 to its merge-forward commit')
 		t.ok(gitCalls.find(c => c.includes('push:origin release-5.8')),
 			'should push updated release-5.8')
@@ -385,29 +385,6 @@ tap.test('run', async t => {
 		t.equal(action.terminalBranch, 'main')
 	})
 
-	t.test('detects merge-forward PR and extracts original PR number', async t => {
-		const core = mockCore({})
-		const action = new TestAutoMerger({
-			pullRequest: {
-				merged: true,
-				base: { ref: 'merge-forward-pr-12345-release-5-8-0' }
-			},
-			baseBranch: 'merge-forward-pr-12345-release-5-8-0',
-			config: {
-				mergeTargets: ['release-5.7.0', 'release-5.8.0', 'main']
-			},
-			core
-		})
-
-		const isMergeForward = action.isMergeForwardPR()
-		const originalPR = action.getOriginalPRNumber()
-		const targetBranch = action.getMergeForwardTargetBranch()
-
-		t.equal(isMergeForward, true, 'should detect merge-forward PR')
-		t.equal(originalPR, '12345', 'should extract original PR number')
-		t.equal(targetBranch, 'release-5.8.0', 'should extract target branch')
-	})
-
 	t.test('detects non-merge-forward PR', async t => {
 		const core = mockCore({})
 		const action = new TestAutoMerger({
@@ -439,7 +416,7 @@ tap.test('run', async t => {
 		}
 
 		const action = new TestAction({
-			baseBranch: 'merge-forward-pr-12345-release-5-8-0',
+			baseBranch: 'merge-forward-pr-12345-release-5.8.0',
 			config: {
 				branches: {
 					'release-5.7.0': {},
@@ -542,11 +519,11 @@ tap.test('handleConflicts', async t => {
 		t.ok(gitCommands.find(c => c.includes('reset')), 'should reset branch')
 
 		// merge-conflicts should be based on the TARGET (main) so forward merging works
-		t.ok(gitCommands.find(c => c.includes('createBranch:merge-conflicts-68586-pr-999-release-5-8-0-to-main:main')),
+		t.ok(gitCommands.find(c => c.includes('createBranch:merge-conflicts-68586-pr-999-release-5.8.0-to-main:main')),
 			'should create merge-conflicts based on TARGET (main) for forward merging')
 
 		// Previous merge-forward is NOT created here - it was created by merge() at start
-		t.notOk(gitCommands.find(c => c.includes('createBranch:merge-forward-pr-999-release-5-8-0')),
+		t.notOk(gitCommands.find(c => c.includes('createBranch:merge-forward-pr-999-release-5.8.0')),
 			'should NOT create previous merge-forward (merge() creates it at start)')
 
 		// merge-forward for the target is ALSO NOT created here - merge() creates it at start
@@ -669,8 +646,8 @@ tap.test('handleConflicts', async t => {
 		//
 		// Scenario:
 		// 1. PR merged to release-5.7.1 (base branch)
-		// 2. Auto-merge to release-5.7.2 succeeds, creates merge-forward-pr-999-release-5-7-2
-		// 3. Auto-merge to release-5.8.0 succeeds, creates merge-forward-pr-999-release-5-8-0
+		// 2. Auto-merge to release-5.7.2 succeeds, creates merge-forward-pr-999-release-5.7.2
+		// 3. Auto-merge to release-5.8.0 succeeds, creates merge-forward-pr-999-release-5.8.0
 		// 4. Auto-merge to main succeeds, creates merge-forward-pr-999-main
 		// 5. All branches should have unique names (no duplicates)
 		//
@@ -745,9 +722,9 @@ tap.test('handleConflicts', async t => {
 
 		// Verify each branch got its own uniquely-named merge-forward branch
 		// The key assertion: branch names should be based on TARGET, not source
-		t.ok(createdBranches.has('merge-forward-pr-999-release-5-7-2'),
+		t.ok(createdBranches.has('merge-forward-pr-999-release-5.7.2'),
 			'should create merge-forward branch named after release-5.7.2 target')
-		t.ok(createdBranches.has('merge-forward-pr-999-release-5-8-0'),
+		t.ok(createdBranches.has('merge-forward-pr-999-release-5.8.0'),
 			'should create merge-forward branch named after release-5.8.0 target')
 		t.ok(createdBranches.has('merge-forward-pr-999-main'),
 			'should create merge-forward branch named after main target')
@@ -758,12 +735,12 @@ tap.test('handleConflicts', async t => {
 
 		// Each merge-forward branch should be created exactly once at the START of merge()
 		// then updated (via git branch -f) at the END of merge()
-		const forwardBranchFor572 = branchCreationOrder.filter(b => b === 'merge-forward-pr-999-release-5-7-2')
-		const forwardBranchFor580 = branchCreationOrder.filter(b => b === 'merge-forward-pr-999-release-5-8-0')
+		const forwardBranchFor572 = branchCreationOrder.filter(b => b === 'merge-forward-pr-999-release-5.7.2')
+		const forwardBranchFor580 = branchCreationOrder.filter(b => b === 'merge-forward-pr-999-release-5.8.0')
 		const forwardBranchForMain = branchCreationOrder.filter(b => b === 'merge-forward-pr-999-main')
 
-		t.equal(forwardBranchFor572.length, 1, 'merge-forward-pr-999-release-5-7-2 should be created once')
-		t.equal(forwardBranchFor580.length, 1, 'merge-forward-pr-999-release-5-8-0 should be created once')
+		t.equal(forwardBranchFor572.length, 1, 'merge-forward-pr-999-release-5.7.2 should be created once')
+		t.equal(forwardBranchFor580.length, 1, 'merge-forward-pr-999-release-5.8.0 should be created once')
 		t.equal(forwardBranchForMain.length, 1, 'merge-forward-pr-999-main should be created once')
 	})
 
@@ -899,7 +876,7 @@ tap.test('writeComment', async t => {
 			issueNumber: 54321,
 			conflicts: 'src/app.js\nsrc/config.js',
 			conflictIssueNumber: 99999,
-			conflictBranchName: 'merge-conflicts-99999-release-5-7-to-release-5-8'
+			conflictBranchName: 'merge-conflicts-99999-release-5.7-to-release-5.8'
 		})
 
 		cleanupIssueCommentFile(t)
@@ -913,7 +890,7 @@ tap.test('writeComment', async t => {
 		t.ok(content.includes('pull request #12345'), 'should reference original PR')
 		t.ok(content.includes('for issue #54321'), 'should reference issue number')
 		t.ok(content.includes('git fetch'), 'should include git fetch command')
-		t.ok(content.includes('merge-conflicts-99999-release-5-7-to-release-5-8'), 'should use merge-conflicts branch name')
+		t.ok(content.includes('merge-conflicts-99999-release-5.7-to-release-5.8'), 'should use merge-conflicts branch name')
 		// When conflict at first target, we merge PR commit directly
 		t.ok(content.includes('git merge xyz789abc123'),
 			'should merge PR commit directly (no prior merge-forward at first target)')
@@ -924,7 +901,7 @@ tap.test('writeComment', async t => {
 		t.ok(content.includes('Fixes #99999'), 'should include Fixes keyword for new issue')
 		t.ok(content.includes('- src/app.js'), 'should list first conflict file')
 		t.ok(content.includes('- src/config.js'), 'should list second conflict file')
-		t.ok(content.includes('merge-forward-pr-12345-release-5-8'), 'should target merge-forward branch for PR')
+		t.ok(content.includes('merge-forward-pr-12345-release-5.8'), 'should target merge-forward branch for PR')
 	})
 
 	t.test('merges forward (few commits) instead of backward (thousands)', async t => {
@@ -953,7 +930,7 @@ tap.test('writeComment', async t => {
 			issueNumber: 222,
 			conflicts: 'file.js',
 			conflictIssueNumber: 333,
-			conflictBranchName: 'merge-conflicts-333-release-5-8-0-to-main'
+			conflictBranchName: 'merge-conflicts-333-release-5.8.0-to-main'
 		})
 
 		cleanupIssueCommentFile(t)
@@ -961,12 +938,12 @@ tap.test('writeComment', async t => {
 		const content = await readFile(filename, 'utf-8')
 
 		// Should checkout the existing merge-conflicts branch (not create a new one)
-		t.ok(content.includes('git checkout merge-conflicts-333-release-5-8-0-to-main'),
+		t.ok(content.includes('git checkout merge-conflicts-333-release-5.8.0-to-main'),
 			'should checkout the existing merge-conflicts branch')
 
 		// Should merge the PREVIOUS step's merge-forward (the PR's progress) INTO merge-conflicts
 		// This is forward merging (few commits) not backward merging (thousands)
-		t.ok(content.includes('git merge origin/merge-forward-pr-456-release-5-8-0'),
+		t.ok(content.includes('git merge origin/merge-forward-pr-456-release-5.8.0'),
 			'should merge the previous merge-forward branch forward')
 		t.notOk(content.includes('git merge main'),
 			'should NOT merge target backward (thousands of commits)')
@@ -995,7 +972,7 @@ tap.test('writeComment', async t => {
 			issueNumber: null,  // No issue linked to PR
 			conflicts: 'test.js',
 			conflictIssueNumber: 888,
-			conflictBranchName: 'merge-conflicts-888-release-5-7-0-to-release'
+			conflictBranchName: 'merge-conflicts-888-release-5.7.0-to-release'
 		})
 
 		cleanupIssueCommentFile(t)
@@ -1004,7 +981,7 @@ tap.test('writeComment', async t => {
 
 		t.ok(content.includes('pull request #777'), 'should still reference PR')
 		t.notOk(content.includes('for issue #'), 'should not mention issue when none exists')
-		t.ok(content.includes('merge-conflicts-888-release-5-7-0-to-release'), 'should use merge-conflicts branch name')
+		t.ok(content.includes('merge-conflicts-888-release-5.7.0-to-release'), 'should use merge-conflicts branch name')
 	})
 
 	t.test('branch name uses conflict issue number, not original PR issue', async t => {
@@ -1028,14 +1005,14 @@ tap.test('writeComment', async t => {
 			issueNumber: 99999,  // Original PR was fixing issue #99999
 			conflicts: 'file.js',
 			conflictIssueNumber: 11111,  // New conflict issue
-			conflictBranchName: 'merge-conflicts-11111-release-5-7-2-to-release-5-8-0'
+			conflictBranchName: 'merge-conflicts-11111-release-5.7.2-to-release-5.8.0'
 		})
 
 		cleanupIssueCommentFile(t)
 
 		const content = await readFile(filename, 'utf-8')
 
-		t.ok(content.includes('merge-conflicts-11111-release-5-7-2-to-release-5-8-0'),
+		t.ok(content.includes('merge-conflicts-11111-release-5.7.2-to-release-5.8.0'),
 			'should use merge-conflicts branch name')
 		t.notOk(content.includes('issue-11111-pr-12345'),
 			'should not use old issue-* branch naming scheme')
@@ -1047,7 +1024,7 @@ tap.test('writeComment', async t => {
 		// This test reproduces the production bug from issue #69524 where:
 		// 1. PR #69510 was merged to release-5.8.0 (base branch)
 		// 2. Conflict occurred at main (first merge target)
-		// 3. Issue instructions referenced merge-forward-pr-69510-release-5-8-0
+		// 3. Issue instructions referenced merge-forward-pr-69510-release-5.8.0
 		// 4. But that branch never existed (only merge-forward for targets, not base)
 		const core = mockCore({})
 		const { readFile } = require('fs/promises')
@@ -1071,15 +1048,15 @@ tap.test('writeComment', async t => {
 			issueNumber: 69497,
 			conflicts: 'cms/src/com/spider/cms/forms/api/FormsController.java',
 			conflictIssueNumber: 69524,
-			conflictBranchName: 'merge-conflicts-69524-release-5-8-0-to-main'
+			conflictBranchName: 'merge-conflicts-69524-release-5.8.0-to-main'
 		})
 
 		cleanupIssueCommentFile(t)
 
 		const content = await readFile(filename, 'utf-8')
 
-		// Should NOT reference merge-forward-pr-69510-release-5-8-0 (doesn't exist!)
-		t.notOk(content.includes('merge-forward-pr-69510-release-5-8-0'),
+		// Should NOT reference merge-forward-pr-69510-release-5.8.0 (doesn't exist!)
+		t.notOk(content.includes('merge-forward-pr-69510-release-5.8.0'),
 			'should NOT reference merge-forward branch for base (it does not exist)')
 
 		// Should reference the PR commit SHA directly
@@ -1139,8 +1116,8 @@ tap.test('Scenario Beta: Two PRs with conflicts at same point are isolated', asy
 		const branchA = actionA.createMergeForwardBranchName('release-5.8.0')
 		const branchB = actionB.createMergeForwardBranchName('release-5.8.0')
 
-		t.equal(branchA, 'merge-forward-pr-111-release-5-8-0', 'User A gets their own merge-forward branch')
-		t.equal(branchB, 'merge-forward-pr-222-release-5-8-0', 'User B gets their own merge-forward branch')
+		t.equal(branchA, 'merge-forward-pr-111-release-5.8.0', 'User A gets their own merge-forward branch')
+		t.equal(branchB, 'merge-forward-pr-222-release-5.8.0', 'User B gets their own merge-forward branch')
 		t.not(branchA, branchB, 'Different PRs get different merge-forward branches for same target')
 	})
 
@@ -1152,9 +1129,9 @@ tap.test('Scenario Beta: Two PRs with conflicts at same point are isolated', asy
 		const conflictBranchA = actionA.createMergeConflictsBranchName(68001, 'release-5.7.0', 'main')
 		const conflictBranchB = actionB.createMergeConflictsBranchName(68002, 'release-5.7.0', 'main')
 
-		t.equal(conflictBranchA, 'merge-conflicts-68001-pr-111-release-5-7-0-to-main',
+		t.equal(conflictBranchA, 'merge-conflicts-68001-pr-111-release-5.7.0-to-main',
 			'User A gets conflict branch with their issue and PR number')
-		t.equal(conflictBranchB, 'merge-conflicts-68002-pr-222-release-5-7-0-to-main',
+		t.equal(conflictBranchB, 'merge-conflicts-68002-pr-222-release-5.7.0-to-main',
 			'User B gets conflict branch with their issue and PR number')
 		t.not(conflictBranchA, conflictBranchB,
 			'Different issues get different conflict branches even for same merge path')

--- a/test/branch-maintainer-test.js
+++ b/test/branch-maintainer-test.js
@@ -87,10 +87,10 @@ tap.test('cleanupMergeConflictsBranch detects encoded merge-conflicts branches',
 			number: 2,
 			title: 'Merge conflicts #68895',
 			head: {
-				ref: 'merge-conflicts-68895-release-5-7-2-to-release-5-8-0'
+				ref: 'merge-conflicts-68895-release-5.7.2-to-release-5.8.0'
 			},
 			base: {
-				ref: 'merge-forward-pr-456-release-5-8-0' // Not terminal branch
+				ref: 'merge-forward-pr-456-release-5.8.0' // Not terminal branch
 			},
 			body: 'Fixes #68895'
 		},
@@ -103,7 +103,7 @@ tap.test('cleanupMergeConflictsBranch detects encoded merge-conflicts branches',
 
 	t.equal(deletedBranches.length, 1, 'should delete the merge-conflicts branch')
 	// Now deletes full branch name, not just prefix+issue
-	t.equal(deletedBranches[0], 'merge-conflicts-68895-release-5-7-2-to-release-5-8-0',
+	t.equal(deletedBranches[0], 'merge-conflicts-68895-release-5.7.2-to-release-5.8.0',
 		'should delete the full branch name')
 })
 
@@ -139,8 +139,8 @@ tap.test('cleanupMergeForwardBranches', async t => {
 		const execBehavior = createGitShellBehavior({
 			mergeForwardBranches: {
 				'12345': [
-					{ branch: 'release-5-7', sha: 'sha1' },
-					{ branch: 'release-5-8', sha: 'sha2' },
+					{ branch: 'release-5.7', sha: 'sha1' },
+					{ branch: 'release-5.8', sha: 'sha2' },
 					{ branch: 'main', sha: 'sha3' }
 				]
 			}
@@ -170,8 +170,8 @@ tap.test('cleanupMergeForwardBranches', async t => {
 		await maintainer.cleanupMergeForwardBranches()
 
 		t.equal(deletedBranches.length, 3, 'should delete all three merge-forward branches')
-		t.ok(deletedBranches.includes('merge-forward-pr-12345-release-5-7'), 'should delete release-5-7 branch')
-		t.ok(deletedBranches.includes('merge-forward-pr-12345-release-5-8'), 'should delete release-5-8 branch')
+		t.ok(deletedBranches.includes('merge-forward-pr-12345-release-5.7'), 'should delete release-5.7 branch')
+		t.ok(deletedBranches.includes('merge-forward-pr-12345-release-5.8'), 'should delete release-5.8 branch')
 		t.ok(deletedBranches.includes('merge-forward-pr-12345-main'), 'should delete main branch')
 	})
 
@@ -217,7 +217,7 @@ tap.test('run calls cleanup when commits reach main', async t => {
 	const execBehavior = createGitShellBehavior({
 		mergeForwardBranches: {
 			'555': [
-				{ branch: 'release-5-7', sha: 'sha1' },
+				{ branch: 'release-5.7', sha: 'sha1' },
 				{ branch: 'main', sha: 'sha2' }
 			]
 		}
@@ -254,7 +254,7 @@ tap.test('run calls cleanup when commits reach main', async t => {
 	await maintainer.run({ automergeConflictBranch: null })
 
 	t.ok(deletedBranches.length > 0, 'should cleanup merge-forward branches when commits reach main')
-	t.ok(deletedBranches.includes('merge-forward-pr-555-release-5-7'), 'should delete merge-forward branches')
+	t.ok(deletedBranches.includes('merge-forward-pr-555-release-5.7'), 'should delete merge-forward branches')
 })
 
 tap.test('run does not cleanup when commits blocked', async t => {
@@ -264,7 +264,7 @@ tap.test('run does not cleanup when commits blocked', async t => {
 	const execBehavior = createGitShellBehavior({
 		mergeForwardBranches: {
 			'666': [
-				{ branch: 'release-5-7', sha: 'sha1' }
+				{ branch: 'release-5.7', sha: 'sha1' }
 			]
 		}
 	})

--- a/test/branch-name-utils-test.js
+++ b/test/branch-name-utils-test.js
@@ -1,0 +1,72 @@
+const tap = require('tap')
+const { 
+	extractPRFromMergeForward,
+	extractPRFromMergeConflicts,
+	extractTargetFromMergeForward
+} = require('../src/branch-name-utils')
+
+tap.test('extractPRFromMergeForward', async t => {
+	t.test('extracts PR number from merge-forward branch', async t => {
+		const result = extractPRFromMergeForward('merge-forward-pr-12345-release-5.8.0')
+		t.equal(result, '12345')
+	})
+
+	t.test('extracts PR number when target is main', async t => {
+		const result = extractPRFromMergeForward('merge-forward-pr-999-main')
+		t.equal(result, '999')
+	})
+
+	t.test('returns null for non-merge-forward branch', async t => {
+		const result = extractPRFromMergeForward('feature-branch')
+		t.equal(result, null)
+	})
+
+	t.test('returns null for merge-conflicts branch', async t => {
+		const result = extractPRFromMergeForward('merge-conflicts-123-pr-456-release-5.8.0-to-main')
+		t.equal(result, null)
+	})
+})
+
+tap.test('extractPRFromMergeConflicts', async t => {
+	t.test('extracts PR number from merge-conflicts branch', async t => {
+		const result = extractPRFromMergeConflicts('merge-conflicts-68586-pr-12345-release-5.8.0-to-main')
+		t.equal(result, '12345')
+	})
+
+	t.test('extracts PR from branch with multiple release versions', async t => {
+		const result = extractPRFromMergeConflicts('merge-conflicts-999-pr-456-release-5.7.2-to-release-5.8.0')
+		t.equal(result, '456')
+	})
+
+	t.test('returns null for non-merge-conflicts branch', async t => {
+		const result = extractPRFromMergeConflicts('feature-branch')
+		t.equal(result, null)
+	})
+
+	t.test('returns null for merge-forward branch', async t => {
+		const result = extractPRFromMergeConflicts('merge-forward-pr-123-main')
+		t.equal(result, null)
+	})
+})
+
+tap.test('extractTargetFromMergeForward', async t => {
+	t.test('extracts target branch from merge-forward', async t => {
+		const result = extractTargetFromMergeForward('merge-forward-pr-123-release-5.8.0')
+		t.equal(result, 'release-5.8.0')
+	})
+
+	t.test('extracts main as target', async t => {
+		const result = extractTargetFromMergeForward('merge-forward-pr-456-main')
+		t.equal(result, 'main')
+	})
+
+	t.test('handles branch names with multiple dots', async t => {
+		const result = extractTargetFromMergeForward('merge-forward-pr-789-release-5.7.2')
+		t.equal(result, 'release-5.7.2')
+	})
+
+	t.test('returns branch without prefix for malformed branch', async t => {
+		const result = extractTargetFromMergeForward('merge-forward-pr-123')
+		t.equal(result, 'merge-forward-pr-123')
+	})
+})

--- a/test/real-git-test.js
+++ b/test/real-git-test.js
@@ -343,7 +343,7 @@ tap.test('Phase 1b: Multi-step chain (merges through release, then conflicts at 
 	t.equal(conflictBranch, 'main', 'conflict should be at main, not release-5.8.0')
 
 	// Verify merge-forward branch was created for successful step
-	t.ok(createdBranches.includes('merge-forward-pr-999-release-5-8-0'),
+	t.ok(createdBranches.includes('merge-forward-pr-999-release-5.8.0'),
 		'should create merge-forward branch for successful release-5.8.0 merge')
 
 	// Verify merge-forward branch was created for conflict step
@@ -711,11 +711,11 @@ tap.test('Resume chain: continues merge chain after conflict resolution', async 
 
 	// Also create merge-forward for release-5.8.0 (from successful first step)
 	git('checkout branch-here-release-5.8.0')
-	git('checkout -b merge-forward-pr-123-release-5-8-0')
+	git('checkout -b merge-forward-pr-123-release-5.8.0')
 	await writeFile(join(repoDir, 'test.txt'), 'PR CONTENT\n')
 	git('add test.txt')
 	git('commit -m "PR merge to release-5.8.0"')
-	git('push origin merge-forward-pr-123-release-5-8-0')
+	git('push origin merge-forward-pr-123-release-5.8.0')
 
 	// Use real Shell and Git
 	const { Shell, Git } = require('gh-action-components')
@@ -758,7 +758,7 @@ tap.test('Resume chain: continues merge chain after conflict resolution', async 
 		prNumber: 456, // This is the resolution PR number
 		prAuthor: 'developer',
 		prTitle: 'Resolve conflicts',
-		prBranch: 'merge-conflicts-999-release-5-8-0-to-main', // Source branch
+		prBranch: 'merge-conflicts-999-release-5.8.0-to-main', // Source branch
 		baseBranch: 'merge-forward-pr-123-main', // Target is merge-forward
 		prCommitSha: resolvedCommit,
 		core,
@@ -843,11 +843,11 @@ tap.test('Terminal branch (main) is updated when merge-forward chain completes',
 
 	// Also create merge-forward for release-5.8.0 (from successful first step)
 	git('checkout branch-here-release-5.8.0')
-	git('checkout -b merge-forward-pr-123-release-5-8-0')
+	git('checkout -b merge-forward-pr-123-release-5.8.0')
 	await writeFile(join(repoDir, 'test.txt'), 'PR CONTENT\n')
 	git('add test.txt')
 	git('commit -m "PR merge to release-5.8.0"')
-	git('push origin merge-forward-pr-123-release-5-8-0')
+	git('push origin merge-forward-pr-123-release-5.8.0')
 
 	// Use real Shell and Git
 	const { Shell, Git } = require('gh-action-components')
@@ -880,7 +880,7 @@ tap.test('Terminal branch (main) is updated when merge-forward chain completes',
 		prNumber: 123, // Original PR number (matches merge-forward branch name)
 		prAuthor: 'developer',
 		prTitle: 'Resolve conflicts',
-		prBranch: 'merge-conflicts-999-release-5-8-0-to-main',
+		prBranch: 'merge-conflicts-999-release-5.8.0-to-main',
 		baseBranch: 'merge-forward-pr-123-main',
 		prCommitSha: resolvedCommit,
 		core,
@@ -977,8 +977,8 @@ tap.test('branch-here should NOT advance past blocked commits when another PR su
 	// Simulate: Cole's merge-forward chain was created but BLOCKED at main
 	// (merge-conflicts branch exists, issue created, but not resolved yet)
 	git('checkout main')
-	git('checkout -b merge-conflicts-69824-pr-69448-release-5-8-0-to-main')
-	git('push origin merge-conflicts-69824-pr-69448-release-5-8-0-to-main')
+	git('checkout -b merge-conflicts-69824-pr-69448-release-5.8.0-to-main')
+	git('push origin merge-conflicts-69824-pr-69448-release-5.8.0-to-main')
 	git('checkout release-5.8.0')
 
 	// Another PR (successful one): modifies other.txt (no conflict)
@@ -1111,16 +1111,16 @@ tap.test('Conflict resolution PR merged to main cleans up merge-forward branches
 	// Simulate PR #69561's merge-forward branches that were created during
 	// the original action run (before conflict at main was detected)
 	git('checkout branch-here-release-5.8.0')
-	git('checkout -b merge-forward-pr-69561-release-5-8-0')
+	git('checkout -b merge-forward-pr-69561-release-5.8.0')
 	await writeFile(join(repoDir, 'test.txt'), 'PR CONTENT\n')
 	git('add test.txt')
 	git('commit -m "PR merge to release-5.8.0"')
-	git('push origin merge-forward-pr-69561-release-5-8-0')
+	git('push origin merge-forward-pr-69561-release-5.8.0')
 
 	// Also update release-5.8.0 to have the PR content
 	// (In real scenario, this happens via updateTargetBranches when chain completes)
 	git('checkout release-5.8.0')
-	git('merge --ff-only merge-forward-pr-69561-release-5-8-0')
+	git('merge --ff-only merge-forward-pr-69561-release-5.8.0')
 	git('push origin release-5.8.0')
 
 	// merge-forward for main was also created (before conflict was detected)
@@ -1133,13 +1133,13 @@ tap.test('Conflict resolution PR merged to main cleans up merge-forward branches
 	git('checkout main')
 	await writeFile(join(repoDir, 'test.txt'), 'RESOLVED CONTENT\n')
 	git('add test.txt')
-	git('commit -m "Merge merge-forward-pr-69561-release-5-8-0 Fixes #69569"')
+	git('commit -m "Merge merge-forward-pr-69561-release-5.8.0 Fixes #69569"')
 	const resolvedCommit = git('rev-parse HEAD')
 	git('push origin main')
 
 	// Verify merge-forward branches exist before running maintainer
 	const branchesBefore = git('ls-remote --heads origin')
-	t.ok(branchesBefore.includes('merge-forward-pr-69561-release-5-8-0'),
+	t.ok(branchesBefore.includes('merge-forward-pr-69561-release-5.8.0'),
 		'merge-forward for release-5.8.0 should exist before maintenance')
 	t.ok(branchesBefore.includes('merge-forward-pr-69561-main'),
 		'merge-forward for main should exist before maintenance')
@@ -1168,14 +1168,14 @@ tap.test('Conflict resolution PR merged to main cleans up merge-forward branches
 	const BranchMaintainer = require('../src/branch-maintainer')
 
 	// Simulate what happens when PR #69582 was merged:
-	// - Head branch: merge-conflicts-69569-pr-69561-release-5-8-0-to-main
+	// - Head branch: merge-conflicts-69569-pr-69561-release-5.8.0-to-main
 	// - Base branch: main (NOT merge-forward-pr-69561-main!)
 	// - This is the incorrect merge that bypassed the merge-forward branch
 	const maintainer = new BranchMaintainer({
 		pullRequest: {
 			merged: true,
 			number: 69582,
-			head: { ref: 'merge-conflicts-69569-pr-69561-release-5-8-0-to-main' },
+			head: { ref: 'merge-conflicts-69569-pr-69561-release-5.8.0-to-main' },
 			base: { ref: 'main' }
 		},
 		config: {
@@ -1203,7 +1203,7 @@ tap.test('Conflict resolution PR merged to main cleans up merge-forward branches
 	// When a merge-conflicts PR is merged, we should clean up the associated
 	// merge-forward branches. The issue number in the branch name (69569) links
 	// to the original PR (69561) that created the merge-forward branches.
-	t.notOk(branchesAfter.includes('merge-forward-pr-69561-release-5-8-0'),
+	t.notOk(branchesAfter.includes('merge-forward-pr-69561-release-5.8.0'),
 		'merge-forward for release-5.8.0 should be cleaned up')
 	t.notOk(branchesAfter.includes('merge-forward-pr-69561-main'),
 		'merge-forward for main should be cleaned up')
@@ -1256,12 +1256,12 @@ tap.test('branch-here advances incrementally via merge-forward (issue #11)', asy
 
 	// PR1's merge-forward branch: adds file1.txt (will complete successfully)
 	git('checkout branch-here-release-5.8.0')
-	git('checkout -b merge-forward-pr-111-release-5-8-0')
+	git('checkout -b merge-forward-pr-111-release-5.8.0')
 	await writeFile(join(repoDir, 'file1.txt'), 'PR1 content\n')
 	git('add file1.txt')
 	git('commit -m "PR1 changes"')
 	const pr1MergeForwardCommit = git('rev-parse HEAD')
-	git('push -u origin merge-forward-pr-111-release-5-8-0')
+	git('push -u origin merge-forward-pr-111-release-5.8.0')
 
 	// PR1's merge-forward for main (also exists, will be cleaned up)
 	git('checkout main')
@@ -1273,16 +1273,16 @@ tap.test('branch-here advances incrementally via merge-forward (issue #11)', asy
 
 	// PR2's merge-forward branch: adds file2.txt (will be blocked)
 	git('checkout branch-here-release-5.8.0')
-	git('checkout -b merge-forward-pr-222-release-5-8-0')
+	git('checkout -b merge-forward-pr-222-release-5.8.0')
 	await writeFile(join(repoDir, 'file2.txt'), 'PR2 content\n')
 	git('add file2.txt')
 	git('commit -m "PR2 changes"')
-	git('push -u origin merge-forward-pr-222-release-5-8-0')
+	git('push -u origin merge-forward-pr-222-release-5.8.0')
 
 	// PR2 is blocked: create merge-conflicts branch
 	git('checkout main')
-	git('checkout -b merge-conflicts-999-pr-222-release-5-8-0-to-main')
-	git('push -u origin merge-conflicts-999-pr-222-release-5-8-0-to-main')
+	git('checkout -b merge-conflicts-999-pr-222-release-5.8.0-to-main')
+	git('push -u origin merge-conflicts-999-pr-222-release-5.8.0-to-main')
 
 	// Verify setup
 	const branchHereBefore = git('rev-parse origin/branch-here-release-5.8.0')
@@ -1311,7 +1311,7 @@ tap.test('branch-here advances incrementally via merge-forward (issue #11)', asy
 		pullRequest: {
 			merged: true,
 			number: 333,
-			head: { ref: 'merge-conflicts-888-pr-111-release-5-8-0-to-main' },
+			head: { ref: 'merge-conflicts-888-pr-111-release-5.8.0-to-main' },
 			base: { ref: 'main' }
 		},
 		config: {
@@ -1334,13 +1334,13 @@ tap.test('branch-here advances incrementally via merge-forward (issue #11)', asy
 
 	// Verify PR1's merge-forward branches were cleaned up
 	const branchesAfter = git('ls-remote --heads origin')
-	t.notOk(branchesAfter.includes('merge-forward-pr-111-release-5-8-0'),
+	t.notOk(branchesAfter.includes('merge-forward-pr-111-release-5.8.0'),
 		'PR1 merge-forward for release-5.8.0 should be cleaned up')
 	t.notOk(branchesAfter.includes('merge-forward-pr-111-main'),
 		'PR1 merge-forward for main should be cleaned up')
 
 	// Verify PR2's merge-forward still exists (chain not complete)
-	t.ok(branchesAfter.includes('merge-forward-pr-222-release-5-8-0'),
+	t.ok(branchesAfter.includes('merge-forward-pr-222-release-5.8.0'),
 		'PR2 merge-forward should still exist (blocked)')
 
 	// KEY ASSERTION: branch-here should include PR1's changes
@@ -1356,4 +1356,107 @@ tap.test('branch-here advances incrementally via merge-forward (issue #11)', asy
 	// Verify PR2's file is NOT in branch-here (PR2 is blocked)
 	t.notOk(pr1FileInBranchHere.includes('file2.txt'),
 		'branch-here should NOT include PR2\'s file (file2.txt) - PR2 is blocked')
+})
+
+tap.test('branch names with periods work without normalization (issue #14)', async t => {
+	// This test verifies that branch names containing periods (e.g., release-5.8.0)
+	// work correctly in merge-forward and merge-conflicts branch names without
+	// needing to normalize them to hyphens (e.g., release-5.8.0).
+	//
+	// The test creates branches with ACTUAL names (periods intact) and verifies
+	// they can be parsed correctly.
+
+	const { repoDir, originDir, git } = await createTestRepo()
+
+	t.teardown(async () => {
+		await cleanupTestRepo(repoDir, originDir)
+	})
+
+	// Setup: Create initial commit
+	await writeFile(join(repoDir, 'test.txt'), 'Initial\n')
+	git('add test.txt')
+	git('commit -m "Initial"')
+
+	// Create release-5.8.0 (with periods)
+	git('checkout -b release-5.8.0')
+	git('push -u origin release-5.8.0')
+
+	// Create branch-here-release-5.8.0
+	git('checkout -b branch-here-release-5.8.0')
+	git('push -u origin branch-here-release-5.8.0')
+
+	// Create main
+	git('checkout -b main')
+	git('push -u origin main')
+
+	// Create merge-forward branch with ACTUAL name (periods, not normalized)
+	git('checkout branch-here-release-5.8.0')
+	git('checkout -b merge-forward-pr-999-release-5.8.0')
+	await writeFile(join(repoDir, 'feature.txt'), 'Feature\n')
+	git('add feature.txt')
+	git('commit -m "Feature commit"')
+	git('push -u origin merge-forward-pr-999-release-5.8.0')
+
+	// Verify the branch name contains periods (not normalized to hyphens)
+	const branches = git('ls-remote --heads origin')
+	t.ok(branches.includes('merge-forward-pr-999-release-5.8.0'),
+		'merge-forward branch should use actual name with periods')
+	t.notOk(branches.includes('merge-forward-pr-999-release-5-8-0'),
+		'merge-forward branch should NOT be normalized to hyphens')
+
+	// Use real Shell
+	const { Shell } = require('gh-action-components')
+	const core = mockCore({})
+	const shell = new Shell(core)
+	shell.exec = async (cmd) => {
+		return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+	}
+	shell.execQuietly = async (cmd) => {
+		try {
+			return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+		} catch (e) {
+			// Silently ignore errors
+		}
+	}
+
+	const BranchMaintainer = require('../src/branch-maintainer')
+
+	// Test that BranchMaintainer can parse and advance branch-here
+	// from a merge-forward branch with periods in the name
+	const maintainer = new BranchMaintainer({
+		pullRequest: {
+			merged: true,
+			number: 888,
+			head: { ref: 'merge-conflicts-777-pr-999-release-5.8.0-to-main' },
+			base: { ref: 'main' }
+		},
+		config: {
+			branches: {
+				'release-5.8.0': {},
+				'main': {}
+			},
+			mergeOperations: {
+				'release-5.8.0': 'main'
+			}
+		},
+		core,
+		shell
+	})
+
+	// This should work without needing to denormalize the branch name
+	await maintainer.run({ automergeConflictBranch: undefined })
+
+	// Fetch updated refs
+	git('fetch origin')
+
+	// Verify branch-here was advanced
+	const branchHereAfter = git('rev-parse origin/branch-here-release-5.8.0')
+	const initialCommit = git('rev-parse HEAD~1')
+	t.not(branchHereAfter, initialCommit,
+		'branch-here should advance when merge-forward branch with periods is cleaned up')
+
+	// Verify merge-forward was deleted
+	const branchesAfter = git('ls-remote --heads origin')
+	t.notOk(branchesAfter.includes('merge-forward-pr-999-release-5.8.0'),
+		'merge-forward branch should be cleaned up')
 })

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -46,7 +46,7 @@ function createMockShell(core, execBehavior = {}) {
  * @param {Object} config.mergeForwardBranches - Map of PR numbers to arrays of branch info
  *   Example: { '12345': [{ branch: 'release-5-7-1', sha: 'abc123' }] }
  * @param {Object} config.revParse - Map of refs to commit SHAs
- *   Example: { 'origin/merge-forward-pr-12345-release-5-7-1': 'commit-sha-5-7-1' }
+ *   Example: { 'origin/merge-forward-pr-12345-release-5.7.1': 'commit-sha-5.7.1' }
  * @param {Function} config.fallback - Optional fallback handler for unmatched commands
  */
 function createGitShellBehavior(config = {}) {


### PR DESCRIPTION
Fixes #14
Related to #11

## Summary

- Removed unnecessary period-to-hyphen normalization in branch names
- Branch names now use actual format (e.g., `release-5.8.0` instead of `release-5-8-0`)
- Created `src/branch-name-utils.js` with shared parsing utilities
- All utilities now reference constants (`MB_BRANCH_FORWARD_PREFIX`, `MB_BRANCH_FAILED_PREFIX`)

## Changes

**New file: `src/branch-name-utils.js`**
- `extractPRFromMergeForward()` - extracts PR number from merge-forward branches
- `extractPRFromMergeConflicts()` - extracts PR number from merge-conflicts branches
- `extractTargetFromMergeForward()` - extracts target branch from merge-forward branches

**Removed:**
- Deleted `denormalizeBranchName()` methods from both AutoMerger and BranchMaintainer
- Removed all `.replace(/\./g, '-')` normalization calls

**Benefits:**
- More readable branch names
- Simpler code (no conversion back and forth)
- DRY principle applied (shared utilities)
- Uses constants throughout

## Test Plan

- ✅ All existing tests pass
- ✅ Added test for branch names with periods
- ✅ All branch name parsing utilities have dedicated tests
- ✅ 95.63% code coverage