### PR TITLE
Fix missing origin/ prefix when creating merge-conflicts branch

### DIFF
--- a/src/automerger.js
+++ b/src/automerger.js
@@ -383,7 +383,9 @@ class AutoMerger {
 			// This pulls just the PR's few commits forward, not thousands backward.
 			const encodedBranchName = this.createMergeConflictsBranchName(
 				newIssueNumber, this.lastSuccessfulBranch, branch)
-			await this.git.createBranch(encodedBranchName, this.getBranchHereRef(branch))
+			const targetRef = this.getBranchHereRef(branch)
+			await this.git.createBranch(
+				encodedBranchName, `origin/${targetRef}`)
 			await this.git.push(`origin ${encodedBranchName}`)
 
 			// Note: merge-forward branch for the target was already created by merge()

--- a/test/auto-merge-action-test.js
+++ b/test/auto-merge-action-test.js
@@ -519,8 +519,8 @@ tap.test('handleConflicts', async t => {
 		t.ok(gitCommands.find(c => c.includes('reset')), 'should reset branch')
 
 		// merge-conflicts should be based on the TARGET (main) so forward merging works
-		t.ok(gitCommands.find(c => c.includes('createBranch:merge-conflicts-68586-pr-999-release-5.8.0-to-main:main')),
-			'should create merge-conflicts based on TARGET (main) for forward merging')
+		t.ok(gitCommands.find(c => c.includes('createBranch:merge-conflicts-68586-pr-999-release-5.8.0-to-main:origin/main')),
+			'should create merge-conflicts based on TARGET (origin/main) for forward merging')
 
 		// Previous merge-forward is NOT created here - it was created by merge() at start
 		t.notOk(gitCommands.find(c => c.includes('createBranch:merge-forward-pr-999-release-5.8.0')),
@@ -620,11 +620,12 @@ tap.test('handleConflicts', async t => {
 
 		await action.handleConflicts('release-5.7.1')
 
-		// Verify merge-conflicts branch was created
+		// Verify merge-conflicts branch was created from origin/ ref
 		const createBranchCmd = gitCommands.find(c =>
-			c.includes('createBranch:merge-conflicts-69864-pr-69847-release-5.7.0-to-release-5.7.1')
+			c.includes('createBranch:merge-conflicts-69864-pr-69847-release-5.7.0-to-release-5.7.1:origin/branch-here-release-5.7.1')
 		)
-		t.ok(createBranchCmd, 'should create merge-conflicts branch')
+		t.ok(createBranchCmd,
+			'should create merge-conflicts branch from origin/ ref')
 
 		// KEY ASSERTION: Verify merge-conflicts branch was pushed to remote
 		const pushCmd = gitCommands.find(c =>


### PR DESCRIPTION
## Summary

`handleConflicts()` was creating the `merge-conflicts` branch from a bare ref (e.g. `branch-here-release-5.8.0`) instead of the remote tracking ref (`origin/branch-here-release-5.8.0`). In the GitHub Actions runner, only remote refs are available, so the branch creation failed.

This caused [impact#70233](https://github.com/SpiderStrategies/impact/issues/70233): the issue was created with instructions pointing to a `merge-conflicts` branch that was never actually created.

The `merge()` method already correctly used `origin/` when creating merge-forward branches -- this makes `handleConflicts()` consistent.

## Test plan

- [x] Existing test updated to assert `origin/` prefix for non-terminal branches
- [x] Existing test updated to assert `origin/main` for terminal branch
- [x] All tests pass

Made with [Cursor](https://cursor.com)