### PR TITLE
fixes #23 Remove maintainBranches to prevent branch-here from advancing past incomplete chains

### DIFF
--- a/test/branch-maintainer-test.js
+++ b/test/branch-maintainer-test.js
@@ -21,38 +21,6 @@ function createDeleteBranchMocks() {
 	return { deletedBranches, core, mockShell }
 }
 
-tap.test('maintainBranches', async t => {
-	const maintainer = new TestBranchMaintainer({
-		config: {
-			branches: { t: {} },
-			mergeOperations: {}
-		}
-	})
-	await maintainer.maintainBranches()
-	// no blowup is the assertion, we expect an immediate break
-})
-
-tap.test('maintainBranches errors', async t => {
-	const coreMock = mockCore({})
-	const mockShell = {
-		core: coreMock,
-		async exec(cmd) {
-			throw new Error('Shell error')
-		}
-	}
-
-	const maintainer = new TestBranchMaintainer({
-		config: {
-			branches: { abc123: {}, efg456: {} },
-			mergeOperations: {}
-		},
-		core: coreMock,
-		shell: mockShell
-	})
-
-	await t.rejects(maintainer.maintainBranches(), 'should throw on error')
-})
-
 tap.test('cleanupMergeConflictsBranch detects simple merge-conflicts branches', async t => {
 	const { deletedBranches, core, mockShell } = createDeleteBranchMocks()
 
@@ -385,64 +353,3 @@ tap.test('advanceBranchHereFromMergeForward', async t => {
 	})
 })
 
-tap.test('fastForward', async t => {
-	t.test('creates new branch when branch does not exist', async t => {
-		const execCalls = []
-		const core = mockCore({})
-
-		const mockShell = {
-			core,
-			async exec(cmd) {
-				execCalls.push(cmd)
-				if (cmd.includes('git ls-remote')) {
-					return ''  // Branch doesn't exist
-				}
-				return ''
-			}
-		}
-
-		const maintainer = new TestBranchMaintainer({
-			core,
-			shell: mockShell
-		})
-
-		await maintainer.fastForward('branch-here-release-5.7', 'abc123')
-
-		t.ok(execCalls.find(c => c.includes('git checkout -b branch-here-release-5.7 abc123')),
-			'should create new branch')
-		t.ok(execCalls.find(c => c.includes('git push --set-upstream')),
-			'should push new branch')
-	})
-
-	t.test('fast-forwards existing branch', async t => {
-		const execCalls = []
-		const core = mockCore({})
-
-		const mockShell = {
-			core,
-			async exec(cmd) {
-				execCalls.push(cmd)
-				if (cmd.includes('git ls-remote')) {
-					return 'refs/heads/branch-here-release-5.7'  // Branch exists
-				}
-				return ''
-			}
-		}
-
-		const maintainer = new TestBranchMaintainer({
-			core,
-			shell: mockShell
-		})
-
-		await maintainer.fastForward('branch-here-release-5.7', 'def456')
-
-		t.ok(execCalls.find(c => c.includes('git checkout branch-here-release-5.7')),
-			'should checkout existing branch')
-		t.ok(execCalls.find(c => c.includes('git pull')),
-			'should pull latest changes')
-		t.ok(execCalls.find(c => c.includes('git merge --ff-only def456')),
-			'should fast-forward merge')
-		t.ok(execCalls.find(c => c.includes('git push --set-upstream')),
-			'should push changes')
-	})
-})

--- a/test/merge-bot-test.js
+++ b/test/merge-bot-test.js
@@ -58,7 +58,6 @@ tap.test('maintainBranchHerePointers', async t => {
 			await runMergeBot()
 
 			t.ok(testState.automergeRan, 'automerge should have run')
-			t.ok(testState.maintainerRan, 'branch maintainer SHOULD run when commits reached main')
 
 			const maintenanceMessage = testState.coreInfoMessages.find(msg =>
 				msg.includes('Running branch maintenance'))

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -250,7 +250,6 @@ function createTestEnvironment({
 	const coreInfoMessages = []
 	const testState = {
 		automergeRan: false,
-		maintainerRan: false,
 		cleanupMergeConflictsBranchCalled: false,
 		terminalBranch: undefined,
 		conflictBranch: undefined,
@@ -308,11 +307,6 @@ function createMergeBotTestActions(testState) {
 		async cleanupMergeConflictsBranch() {
 			testState.cleanupMergeConflictsBranchCalled = true
 			await super.cleanupMergeConflictsBranch()
-		}
-
-		async maintainBranches() {
-			testState.maintainerRan = true
-			// Don't actually run maintenance in tests
 		}
 	}
 


### PR DESCRIPTION
Closes #23

`maintainBranches()` fast-forwarded `branch-here-X` to `origin/X` (the actual release branch), which includes commits from PRs whose merge chains haven't completed to main. Its guard only checked for `merge-conflicts-*-{branch}-to-*`, missing chains blocked further downstream.

`advanceBranchHereFromMergeForward()` (from #11) is the correct and sufficient mechanism. Removed `maintainBranches()` and its helpers (`updateBranchHerePointer`, `fastForward`).

Made with [Cursor](https://cursor.com)