### PR TITLE
fixes #27 Resume merge chain after conflict resolution

### DIFF
--- a/src/automerger.js
+++ b/src/automerger.js
@@ -124,11 +124,6 @@ class AutoMerger {
 	}
 
 	async runMerges() {
-		const username = 'Spider Merge Bot'
-		const userEmail = 'merge-bot@spiderstrategies.com'
-		this.core.info(`Assigning git identity to ${username} <${userEmail}>`)
-		await this.git.configureIdentity(username, userEmail)
-
 		// Determine which branches to merge into
 		let targets
 		if (this.isMergeForwardPR()) {


### PR DESCRIPTION
## Summary

- Extract real target branch from merge-forward base branch before calling configReader, so mergeTargets is always correctly populated
- Move git identity configuration to merge-bot.js so both phases have it
- Remove identity configuration from AutoMerger.runMerges() (now handled by orchestrator)

Closes #27