### PR TITLE
fixes #31 Multi-conflict chains leave orphaned merge-forward branches

### DIFF
--- a/src/branch-name-utils.js
+++ b/src/branch-name-utils.js
@@ -61,8 +61,27 @@ function extractTargetFromMergeForward(branchName) {
 	return branchName.replace(new RegExp(`^${MB_BRANCH_FORWARD_PREFIX}\\d+-`), '')
 }
 
+/**
+ * Determines the original PR number that started this merge
+ * chain. Checks the base ref for a merge-forward branch name,
+ * then the head ref for a merge-conflicts branch name, and
+ * falls back to the PR's own number.
+ *
+ * @param {Object} options
+ * @param {string} options.baseRef - The PR's base branch name
+ * @param {string} options.headRef - The PR's head branch name
+ * @param {number|string} options.prNumber - The PR's own number
+ * @returns {string|number} The original PR number
+ */
+function extractOriginalPRNumber({ baseRef, headRef, prNumber }) {
+	return extractPRFromMergeForward(baseRef ?? '')
+		?? extractPRFromMergeConflicts(headRef ?? '')
+		?? prNumber
+}
+
 module.exports = {
 	extractPRFromMergeForward,
 	extractPRFromMergeConflicts,
-	extractTargetFromMergeForward
+	extractTargetFromMergeForward,
+	extractOriginalPRNumber
 }

--- a/test/branch-name-utils-test.js
+++ b/test/branch-name-utils-test.js
@@ -2,7 +2,8 @@ const tap = require('tap')
 const { 
 	extractPRFromMergeForward,
 	extractPRFromMergeConflicts,
-	extractTargetFromMergeForward
+	extractTargetFromMergeForward,
+	extractOriginalPRNumber
 } = require('../src/branch-name-utils')
 
 tap.test('extractPRFromMergeForward', async t => {
@@ -68,5 +69,43 @@ tap.test('extractTargetFromMergeForward', async t => {
 	t.test('returns branch without prefix for malformed branch', async t => {
 		const result = extractTargetFromMergeForward('merge-forward-pr-123')
 		t.equal(result, 'merge-forward-pr-123')
+	})
+})
+
+tap.test('extractOriginalPRNumber', async t => {
+	t.test('extracts from merge-forward base ref', async t => {
+		t.equal(extractOriginalPRNumber({
+			baseRef: 'merge-forward-pr-70452-release-5.8.0',
+			headRef: 'some-feature-branch',
+			prNumber: 70465
+		}), '70452')
+	})
+
+	t.test('extracts from merge-conflicts head ref', async t => {
+		t.equal(extractOriginalPRNumber({
+			baseRef: 'main',
+			headRef: 'merge-conflicts-70468-pr-70452' +
+				'-release-5.8.0-to-main',
+			prNumber: 70469
+		}), '70452')
+	})
+
+	t.test('prefers base over head when both present',
+			async t => {
+		t.equal(extractOriginalPRNumber({
+			baseRef: 'merge-forward-pr-100-main',
+			headRef: 'merge-conflicts-200-pr-100' +
+				'-release-5.8.0-to-main',
+			prNumber: 999
+		}), '100')
+	})
+
+	t.test('falls back to prNumber for normal PRs',
+			async t => {
+		t.equal(extractOriginalPRNumber({
+			baseRef: 'release-5.7.2',
+			headRef: 'feature-branch',
+			prNumber: 70452
+		}), 70452)
 	})
 })


### PR DESCRIPTION
Closes #31

When a merge chain hit conflicts at multiple points (e.g., both `release-5.8.0` and `main`), each conflict resolution PR created merge-forward branches under its own PR number. Cleanup only searched for the latest PR's branches, leaving earlier ones orphaned and `branch-here` un-advanced.

## Changes

- Added `extractOriginalPRNumber` to `branch-name-utils.js` — shared function that traces back to the original PR number from merge-forward base refs or merge-conflicts head refs
- `AutoMerger.originalPRNumber` getter delegates to the shared function
- `createMergeForwardBranchName` and `createMergeConflictsBranchName` use `originalPRNumber`, keeping the entire chain under one PR number
- Removed duplicate `BranchMaintainer.determineOriginalPRNumber()` (DRY)
- `updateTargetBranches` simplified to use the same getter

Made with [Cursor](https://cursor.com)