### PR TITLE
#31 Address CodeRabbit review feedback

### DIFF
--- a/src/automerger.js
+++ b/src/automerger.js
@@ -118,7 +118,7 @@ class AutoMerger {
 	get originalPRNumber() {
 		return extractOriginalPRNumber({
 			baseRef: this.baseBranch,
-			headRef: this.pullRequest.head?.ref,
+			headRef: this.pullRequest?.head?.ref,
 			prNumber: this.prNumber
 		})
 	}

--- a/test/branch-name-utils-test.js
+++ b/test/branch-name-utils-test.js
@@ -94,7 +94,7 @@ tap.test('extractOriginalPRNumber', async t => {
 			async t => {
 		t.equal(extractOriginalPRNumber({
 			baseRef: 'merge-forward-pr-100-main',
-			headRef: 'merge-conflicts-200-pr-100' +
+			headRef: 'merge-conflicts-200-pr-999' +
 				'-release-5.8.0-to-main',
 			prNumber: 999
 		}), '100')


### PR DESCRIPTION
Follow-up fixes from CodeRabbit's review of PR #32:

- Add optional chaining on `this.pullRequest` in `originalPRNumber` getter to guard against undefined
- Fix "prefers base over head" test to encode different PR numbers so it actually verifies evaluation priority

Related to #31

Made with [Cursor](https://cursor.com)