### PR TITLE
fixes #36 Use commit SHA comparison for push detection

### DIFF
--- a/manual-merge.sh
+++ b/manual-merge.sh
@@ -90,8 +90,8 @@ while IFS=' ' read -r source target; do
     fi
   fi
 
-  # Push if there are unpushed commits
-  if ! git diff --quiet HEAD "origin/$target" 2>/dev/null; then
+  # Push if there are unpushed commits (compare SHAs, not file trees)
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$target")" ]; then
     git push origin "$target"
     log_info "  Pushed successfully."
   else


### PR DESCRIPTION
Fixes #36

`git diff --quiet` compares file trees, not commit history. Merge commits that don't change file content (e.g., already cherry-picked changes) were silently skipped, leaving local commits unpushed on release branches.

Replaces the tree comparison with a `git rev-parse` SHA comparison so any unpushed commits trigger a push regardless of content changes.

Made with [Cursor](https://cursor.com)