### PR TITLE
fixes #71406 branch-here not advanced for PRs merged directly into the last release branch

### DIFF
--- a/src/branch-maintainer.js
+++ b/src/branch-maintainer.js
@@ -2,6 +2,7 @@ const { MB_BRANCH_FAILED_PREFIX, MB_BRANCH_HERE_PREFIX, MB_BRANCH_FORWARD_PREFIX
 const {
 	extractOriginalPRNumber,
 	extractPRFromMergeForward,
+	extractSourceFromMergeConflicts,
 	extractTargetFromMergeForward
 } = require('./branch-name-utils')
 
@@ -65,6 +66,16 @@ class BranchMaintainer {
 		if (shouldCleanup) {
 			this.core.info(`Running branch maintenance: commits reached main`)
 			await this.cleanupMergeForwardBranches()
+
+			// #71406 - When merging from the last release branch into
+			// main, branch-here for that release branch is never
+			// advanced (main has no branch-here). Advance it here
+			// with the PR's head commit.
+			if (commitsReachedMain) {
+				await this.advanceBranchHereAfterReleaseMerge()
+			} else if (mergeConflictsPRCompleted) {
+				await this.advanceBranchHereAfterConflictResolution()
+			}
 		} else if (isTerminalBranch) {
 			this.core.info(`Skipping branch maintenance: PR was against terminal branch, no merge chain traversed`)
 		} else {
@@ -179,29 +190,110 @@ class BranchMaintainer {
 		}
 
 		const prNumber = extractPRFromMergeForward(mergeForwardBranch)
-		const branchHere = MB_BRANCH_HERE_PREFIX + targetBranch
-		this.core.info(
-			`Advancing ${branchHere} from ${mergeForwardBranch}`)
+		await this.advanceBranchHere({
+			releaseBranch: targetBranch,
+			mergeRef: `origin/${mergeForwardBranch}`,
+			prNumber
+		})
+	}
 
-		// Step 1: Merge merge-forward into branch-here
+	/**
+	 * #71406 - Advances branch-here for the release branch the PR
+	 * was merged into. When merging from the last release branch
+	 * into main, that release branch's branch-here is missed
+	 * because main has no branch-here.
+	 */
+	async advanceBranchHereAfterReleaseMerge() {
+		const releaseBranch = this.pullRequest.base.ref
+		if (releaseBranch === this.terminalBranch) {
+			return
+		}
+
+		const mergeRef = this.pullRequest.head?.sha
+		if (!mergeRef) {
+			return
+		}
+
+		await this.advanceBranchHere({
+			releaseBranch,
+			mergeRef,
+			prNumber: this.pullRequest.number
+		})
+	}
+
+	/**
+	 * Same as advanceBranchHereAfterReleaseMerge, but for the
+	 * conflict-resolution path where this.pullRequest is the
+	 * resolution PR (base: main), not the original. Recovers the
+	 * original PR's release branch from the merge-conflicts branch
+	 * name and its head SHA from the GitHub API.
+	 */
+	async advanceBranchHereAfterConflictResolution() {
+		const headRef = this.pullRequest.head?.ref ?? ''
+		const releaseBranch =
+			extractSourceFromMergeConflicts(headRef)
+		if (!releaseBranch ||
+				releaseBranch === this.terminalBranch) {
+			return
+		}
+
+		const prNumber = extractOriginalPRNumber({
+			baseRef: this.pullRequest.base?.ref,
+			headRef,
+			prNumber: this.pullRequest.number
+		})
+		const branchHere = MB_BRANCH_HERE_PREFIX + releaseBranch
+
+		let mergeRef
+		try {
+			mergeRef = await this.shell.exec(
+				`gh pr view ${prNumber}` +
+				` --json headRefOid --jq '.headRefOid'`)
+		} catch (e) {
+			this.core.info(
+				`Could not fetch head SHA for PR` +
+				` #${prNumber}, skipping` +
+				` ${branchHere} advancement`)
+			return
+		}
+		if (!mergeRef) {
+			return
+		}
+
+		await this.advanceBranchHere({
+			releaseBranch, mergeRef, prNumber
+		})
+	}
+
+	/**
+	 * Advances branch-here for a release branch by merging mergeRef
+	 * into it, then merges branch-here back into the release branch
+	 * to preserve ancestry (issue #19).
+	 *
+	 * The ancestry merge is critical: without it, branch-here would
+	 * have a merge commit that doesn't exist on the release branch,
+	 * causing them to diverge.
+	 */
+	async advanceBranchHere({ releaseBranch, mergeRef, prNumber }) {
+		const branchHere = MB_BRANCH_HERE_PREFIX + releaseBranch
+		this.core.info(
+			`Advancing ${branchHere} with PR #${prNumber}`)
+
 		await this.shell.exec(`git checkout ${branchHere}`)
 		await this.shell.exec(`git pull`)
 		await this.shell.exec(
-			`git merge origin/${mergeForwardBranch} --no-ff ` +
+			`git merge ${mergeRef} --no-ff ` +
 			`-m "Merge #${prNumber} into ${branchHere}"`)
 		await this.shell.exec(`git push origin ${branchHere}`)
 
-		// Issue #19 - Merge branch-here into the release branch to
-		// preserve ancestry. Without this, branch-here would diverge
-		// from the release branch because the merge commit above
-		// doesn't exist on the release branch.
-		await this.shell.exec(`git checkout ${targetBranch}`)
+		// Issue #19 - Preserve ancestry
+		await this.shell.exec(`git checkout ${releaseBranch}`)
 		await this.shell.exec(`git pull`)
 		await this.shell.exec(
 			`git merge ${branchHere} --no-ff ` +
 			`-m "Merge #${prNumber} from ${branchHere}` +
-			` to ${targetBranch}"`)
-		await this.shell.exec(`git push origin ${targetBranch}`)
+			` to ${releaseBranch}"`)
+		await this.shell.exec(`git push origin ${releaseBranch}`)
 	}
 
 	/**
@@ -231,4 +323,3 @@ class BranchMaintainer {
 }
 
 module.exports = BranchMaintainer
-

--- a/src/branch-name-utils.js
+++ b/src/branch-name-utils.js
@@ -79,9 +79,24 @@ function extractOriginalPRNumber({ baseRef, headRef, prNumber }) {
 		?? prNumber
 }
 
+/**
+ * Extracts the source branch from a merge-conflicts branch name.
+ * Format: merge-conflicts-{issueNumber}-pr-{prNumber}-{source}-to-{target}
+ * Example: merge-conflicts-71392-pr-71347-release-5.8.0-to-main -> 'release-5.8.0'
+ *
+ * @param {string} branchName - The merge-conflicts branch name
+ * @returns {string|null} The source branch name, or null if not parseable
+ */
+function extractSourceFromMergeConflicts(branchName) {
+	const match = branchName.match(
+		/^merge-conflicts-\d+-pr-\d+-(.+)-to-(.+)$/)
+	return match ? match[1] : null
+}
+
 module.exports = {
 	extractPRFromMergeForward,
 	extractPRFromMergeConflicts,
 	extractTargetFromMergeForward,
+	extractSourceFromMergeConflicts,
 	extractOriginalPRNumber
 }

--- a/test/branch-name-utils-test.js
+++ b/test/branch-name-utils-test.js
@@ -3,6 +3,7 @@ const {
 	extractPRFromMergeForward,
 	extractPRFromMergeConflicts,
 	extractTargetFromMergeForward,
+	extractSourceFromMergeConflicts,
 	extractOriginalPRNumber
 } = require('../src/branch-name-utils')
 
@@ -47,6 +48,29 @@ tap.test('extractPRFromMergeConflicts', async t => {
 	t.test('returns null for merge-forward branch', async t => {
 		const result = extractPRFromMergeConflicts('merge-forward-pr-123-main')
 		t.equal(result, null)
+	})
+})
+
+tap.test('extractSourceFromMergeConflicts', async t => {
+	t.test('extracts source branch targeting main', async t => {
+		t.equal(extractSourceFromMergeConflicts(
+			'merge-conflicts-71392-pr-71347-release-5.8.0-to-main'),
+		'release-5.8.0')
+	})
+
+	t.test('extracts source branch targeting another release', async t => {
+		t.equal(extractSourceFromMergeConflicts(
+			'merge-conflicts-999-pr-456-release-5.7.2-to-release-5.8.0'),
+		'release-5.7.2')
+	})
+
+	t.test('returns null for non-merge-conflicts branch', async t => {
+		t.equal(extractSourceFromMergeConflicts('feature-branch'), null)
+	})
+
+	t.test('returns null for merge-forward branch', async t => {
+		t.equal(extractSourceFromMergeConflicts(
+			'merge-forward-pr-123-main'), null)
 	})
 })
 

--- a/test/real-git-test.js
+++ b/test/real-git-test.js
@@ -1851,6 +1851,269 @@ tap.test('Issue #43: BranchMaintainer merges to main after conflict resolution a
 		'main should have the resolved conflict content')
 })
 
+tap.test('#71406: branch-here advances for base branch when PR merges directly into last release branch', async t => {
+	// When a PR merges directly into release-5.8.0 (the last release before
+	// main), the only merge-forward branch created is merge-forward-pr-N-main
+	// (targeting the terminal branch). branch-here-release-5.8.0 should still
+	// be advanced with the PR's changes once the chain completes to main.
+	//
+	// This is the non-conflict (happy) path.
+
+	const { repoDir, originDir, git } = await createTestRepo()
+
+	t.teardown(async () => {
+		await cleanupTestRepo(repoDir, originDir)
+	})
+
+	// Setup
+	await writeFile(join(repoDir, 'base.txt'), 'Base content\n')
+	git('add .')
+	git('commit -m "Initial"')
+	const initialCommit = git('rev-parse HEAD')
+
+	// Create release-5.8.0
+	git('checkout -b release-5.8.0')
+	git('push -u origin release-5.8.0')
+
+	// Create branch-here-release-5.8.0
+	git('checkout -b branch-here-release-5.8.0')
+	git('push -u origin branch-here-release-5.8.0')
+
+	// Create main
+	git('checkout -b main')
+	git('push -u origin main')
+
+	// Simulate: PR was merged into release-5.8.0 (adds feature.txt)
+	git('checkout release-5.8.0')
+	await writeFile(join(repoDir, 'feature.txt'), 'New feature\n')
+	git('add feature.txt')
+	git('commit -m "PR 888 feature"')
+	const prHeadSha = git('rev-parse HEAD')
+	git('push origin release-5.8.0')
+
+	// Simulate: AutoMerger created merge-forward-pr-888-main
+	// (based on main, with PR changes merged in)
+	// This is the ONLY merge-forward branch — no merge-forward for release-5.8.0
+	git('checkout main')
+	git('checkout -b merge-forward-pr-888-main')
+	await writeFile(join(repoDir, 'feature.txt'), 'New feature\n')
+	git('add feature.txt')
+	git('commit -m "auto-merge of PR 888 into main"')
+	git('push -u origin merge-forward-pr-888-main')
+
+	// Verify setup: branch-here hasn't moved
+	const branchHereBefore = git('rev-parse origin/branch-here-release-5.8.0')
+	t.equal(branchHereBefore, initialCommit,
+		'Setup: branch-here should be at initial commit')
+
+	// Use real Shell
+	const { Shell } = require('gh-action-components')
+	const core = mockCore({})
+	const shell = new Shell(core)
+	shell.exec = async (cmd) => {
+		return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+	}
+	shell.execQuietly = async (cmd) => {
+		try {
+			return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+		} catch (e) {
+			// Silently ignore errors
+		}
+	}
+
+	const BranchMaintainer = require('../src/branch-maintainer')
+
+	// Non-conflict case: PR merged into release-5.8.0, automerge succeeded
+	const maintainer = new BranchMaintainer({
+		pullRequest: {
+			merged: true,
+			number: 888,
+			head: { ref: 'issue-888-feature', sha: prHeadSha },
+			base: { ref: 'release-5.8.0' }
+		},
+		config: {
+			branches: {
+				'release-5.8.0': {},
+				'main': {}
+			},
+			mergeOperations: {
+				'release-5.8.0': 'main'
+			}
+		},
+		core,
+		shell
+	})
+
+	// automergeConflictBranch is undefined because automerge succeeded
+	await maintainer.run({ automergeConflictBranch: undefined })
+
+	// Fetch updated refs
+	git('fetch origin')
+
+	// KEY ASSERTION: branch-here-release-5.8.0 should have been advanced
+	const branchHereAfter = git('rev-parse origin/branch-here-release-5.8.0')
+	t.not(branchHereAfter, initialCommit,
+		'branch-here-release-5.8.0 should have advanced from initial commit')
+
+	// Verify the feature file is in branch-here
+	const branchHereFiles = git(
+		`ls-tree --name-only ${branchHereAfter}`)
+	t.ok(branchHereFiles.includes('feature.txt'),
+		'branch-here should include the PR\'s feature file')
+
+	// Verify branch-here is an ancestor of release-5.8.0 (issue #19)
+	let isAncestor
+	try {
+		git('merge-base --is-ancestor ' +
+			'origin/branch-here-release-5.8.0 origin/release-5.8.0')
+		isAncestor = true
+	} catch (e) {
+		isAncestor = false
+	}
+	t.ok(isAncestor,
+		'branch-here should remain an ancestor of release-5.8.0')
+})
+
+tap.test('#71406: branch-here advances for base branch after conflict resolution at terminal', async t => {
+	// Same bug as above, but for the conflict-resolution path:
+	// 1. PR merges into release-5.8.0
+	// 2. Automerge to main conflicts → merge-forward-pr-N-main created
+	// 3. Developer resolves, PRs merge-conflicts branch to main
+	// 4. BranchMaintainer runs (mergeConflictsPRCompleted = true)
+	// 5. EXPECTED: branch-here-release-5.8.0 should be advanced
+	//
+	// Unlike the non-conflict case, this.pullRequest is the conflict-
+	// resolution PR (base: main), not the original. The original PR's
+	// head SHA must be obtained from the merge-forward branch.
+
+	const { repoDir, originDir, git } = await createTestRepo()
+
+	t.teardown(async () => {
+		await cleanupTestRepo(repoDir, originDir)
+	})
+
+	// Setup
+	await writeFile(join(repoDir, 'base.txt'), 'Base content\n')
+	git('add .')
+	git('commit -m "Initial"')
+	const initialCommit = git('rev-parse HEAD')
+
+	// Create release-5.8.0
+	git('checkout -b release-5.8.0')
+	git('push -u origin release-5.8.0')
+
+	// Create branch-here-release-5.8.0
+	git('checkout -b branch-here-release-5.8.0')
+	git('push -u origin branch-here-release-5.8.0')
+
+	// Create main with different content (will cause conflict)
+	git('checkout -b main')
+	await writeFile(join(repoDir, 'conflict.txt'), 'MAIN VERSION\n')
+	git('add conflict.txt')
+	git('commit -m "Main content"')
+	git('push -u origin main')
+
+	// Simulate: Original PR #71347 was merged into release-5.8.0
+	git('checkout release-5.8.0')
+	await writeFile(join(repoDir, 'feature.txt'), 'New feature\n')
+	git('add feature.txt')
+	git('commit -m "PR 71347 feature"')
+	const originalPrHeadSha = git('rev-parse HEAD')
+	git('push origin release-5.8.0')
+
+	// Simulate: AutoMerger created merge-forward-pr-71347-main from main.
+	// In the conflict case, the merge conflicted and was never committed,
+	// so this branch is just a copy of main at the time. But it DOES exist.
+	git('checkout main')
+	git('checkout -b merge-forward-pr-71347-main')
+	git('push -u origin merge-forward-pr-71347-main')
+
+	// Simulate: Developer resolved the conflict and merged directly to main
+	git('checkout main')
+	await writeFile(join(repoDir, 'feature.txt'), 'New feature\n')
+	git('add feature.txt')
+	git('commit -m "Merge PR 71347 resolved conflicts"')
+	git('push origin main')
+
+	// Verify setup: branch-here hasn't moved
+	const branchHereBefore = git('rev-parse origin/branch-here-release-5.8.0')
+	t.equal(branchHereBefore, initialCommit,
+		'Setup: branch-here should be at initial commit')
+
+	// Use real Shell
+	const { Shell } = require('gh-action-components')
+	const core = mockCore({})
+	const shell = new Shell(core)
+	shell.exec = async (cmd) => {
+		// Mock gh CLI to return the original PR's head SHA
+		if (cmd.includes('gh pr view')) {
+			return originalPrHeadSha
+		}
+		return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+	}
+	shell.execQuietly = async (cmd) => {
+		try {
+			return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+		} catch (e) {
+			// Silently ignore errors
+		}
+	}
+
+	const BranchMaintainer = require('../src/branch-maintainer')
+
+	// Conflict-resolution path: merge-conflicts PR merged into main
+	const maintainer = new BranchMaintainer({
+		pullRequest: {
+			merged: true,
+			number: 71397,
+			head: {
+				ref: 'merge-conflicts-71392-pr-71347-release-5.8.0-to-main',
+				sha: 'irrelevant-conflict-resolution-sha'
+			},
+			base: { ref: 'main' }
+		},
+		config: {
+			branches: {
+				'release-5.8.0': {},
+				'main': {}
+			},
+			mergeOperations: {
+				'release-5.8.0': 'main'
+			}
+		},
+		core,
+		shell
+	})
+
+	await maintainer.run({ automergeConflictBranch: undefined })
+
+	// Fetch updated refs
+	git('fetch origin')
+
+	// KEY ASSERTION: branch-here-release-5.8.0 should have been advanced
+	const branchHereAfter = git('rev-parse origin/branch-here-release-5.8.0')
+	t.not(branchHereAfter, initialCommit,
+		'branch-here-release-5.8.0 should have advanced from initial commit')
+
+	// Verify the feature file is in branch-here
+	const branchHereFiles = git(
+		`ls-tree --name-only ${branchHereAfter}`)
+	t.ok(branchHereFiles.includes('feature.txt'),
+		'branch-here should include the PR\'s feature file')
+
+	// Verify branch-here is an ancestor of release-5.8.0 (issue #19)
+	let isAncestor
+	try {
+		git('merge-base --is-ancestor ' +
+			'origin/branch-here-release-5.8.0 origin/release-5.8.0')
+		isAncestor = true
+	} catch (e) {
+		isAncestor = false
+	}
+	t.ok(isAncestor,
+		'branch-here should remain an ancestor of release-5.8.0')
+})
+
 tap.test('Issue #27: AutoMerger resumes chain when conflict resolution PR merges to merge-forward branch', async t => {
 	// Reproduces the bug from issue #27 where a conflict resolution PR
 	// merged into merge-forward-pr-70412-release-5.8.0, but the bot


### PR DESCRIPTION
Fixes SpiderStrategies/impact#71406

When a PR is merged directly into the last release branch before main (e.g., `release-5.8.0`), `branch-here-release-5.8.0` is now properly advanced after the changes reach main.

## Changes

- When `BranchMaintainer` processes a terminal-targeting merge-forward branch, it now also advances `branch-here` for the original PR's base branch
- Handles both non-conflict path (using `pullRequest.head.sha`) and conflict-resolution path (looking up original PR's head SHA via GitHub API)
- After advancement, merges branch-here into the release branch to maintain ancestry

## Tests

Added comprehensive tests covering both scenarios:
- Non-conflict path: PR merged directly into last release branch
- Conflict-resolution path: Conflict PR merged to main after original PR was merged to release branch

Made with [Cursor](https://cursor.com)