### PR TITLE
fixes #72734 BranchMaintainer crashes when a PR closes against a non-configured base branch

### DIFF
--- a/src/branch-maintainer.js
+++ b/src/branch-maintainer.js
@@ -54,6 +54,23 @@ class BranchMaintainer {
 		// which branch the PR was merged into
 		await this.cleanupMergeConflictsBranch()
 
+		// #72734 - The workflow fires for every closed PR, but
+		// branch-here maintenance only makes sense when the base is
+		// a configured release branch or a merge-forward branch
+		// (the legitimate conflict-resolution target). Without this
+		// guard, a PR merged into a stray feature branch crashes
+		// the maintainer trying to advance `branch-here-<feature>`.
+		const baseRef = this.pullRequest.base.ref
+		const isConfiguredBase = baseRef in this.config.branches
+		const isMergeForwardBase =
+			baseRef.startsWith(MB_BRANCH_FORWARD_PREFIX)
+		if (!isConfiguredBase && !isMergeForwardBase) {
+			this.core.info(
+				`Skipping branch maintenance: base '${baseRef}'` +
+				` is not a configured branch`)
+			return
+		}
+
 		// Determine if commits reached the terminal branch. A
 		// merge-conflicts PR's merge implies the chain completed
 		// (AutoMerger ran first and drove remaining hops; if it

--- a/src/branch-maintainer.js
+++ b/src/branch-maintainer.js
@@ -31,14 +31,10 @@ class BranchMaintainer {
 	}
 
 	/**
-	 * Main entry point - handles all branch maintenance responsibilities:
+	 * Main entry point - orchestrates branch maintenance:
 	 * 1. Delete merge-conflicts branches when conflict PRs are merged
-	 * 2. Maintain branch-here pointers (only if commits reached main)
-	 *
-	 * CRITICAL: Only maintains branch-here when commits have merged ALL THE WAY to main.
-	 * This ensures branch-here branches only include commits that have successfully
-	 * merged through the entire release chain, preventing users from inheriting
-	 * conflicts from earlier in the chain.
+	 * 2. Skip the rest when the base isn't a configured branch
+	 * 3. Maintain branch-here pointers (only if commits reached main)
 	 *
 	 * @param {Object} options
 	 * @param {string} [options.automergeConflictBranch] - The branch where automerge
@@ -71,6 +67,23 @@ class BranchMaintainer {
 			return
 		}
 
+		await this.maintainBranchHere({ automergeConflictBranch })
+	}
+
+	/**
+	 * Cleans up merge-forward branches and advances branch-here
+	 * pointers when commits successfully reached the terminal branch.
+	 *
+	 * CRITICAL: Only advances branch-here when commits have merged ALL THE
+	 * WAY to main. This ensures branch-here branches only include commits
+	 * that have successfully merged through the entire release chain,
+	 * preventing users from inheriting conflicts from earlier in the chain.
+	 *
+	 * @param {Object} options
+	 * @param {string} [options.automergeConflictBranch] - The branch where
+	 *   automerge encountered conflicts (undefined if automerge succeeded)
+	 */
+	async maintainBranchHere({ automergeConflictBranch }) {
 		// Determine if commits reached the terminal branch. A
 		// merge-conflicts PR's merge implies the chain completed
 		// (AutoMerger ran first and drove remaining hops; if it

--- a/test/branch-maintainer-test.js
+++ b/test/branch-maintainer-test.js
@@ -387,3 +387,61 @@ tap.test('advanceBranchHereFromMergeForward', async t => {
 	})
 })
 
+tap.test('run skips maintenance when base is not a configured branch', async t => {
+	// #72734 - When a PR is merged into a non-configured base
+	// (e.g. a feature branch, like PR #72699 was merged into
+	// `72162-geographic-...`), BranchMaintainer used to crash
+	// trying to advance `branch-here-<feature-branch>`. It
+	// should no-op gracefully instead.
+	const execCalls = []
+	const core = mockCore({})
+	const infoMessages = []
+	core.info = (msg) => infoMessages.push(msg)
+
+	const mockShell = {
+		core,
+		async exec(cmd) { execCalls.push(cmd); return '' },
+		async execQuietly(cmd) { execCalls.push(cmd); return '' }
+	}
+
+	const maintainer = new BranchMaintainer({
+		pullRequest: {
+			number: 72699,
+			head: {
+				ref: '72598-missing-variablespunctuation-in' +
+					'-error-messages-in-stack-traces-for' +
+					'-dataset-field',
+				sha: 'abc123'
+			},
+			base: {
+				ref: '72162-geographic-dataset-link-field' +
+					'-never-has-data-show-up-in-the-records-tab'
+			},
+			merged: true
+		},
+		config: {
+			branches: {
+				'release-5.8.0': {},
+				'main': {}
+			},
+			mergeOperations: {}
+		},
+		core,
+		shell: mockShell
+	})
+
+	await maintainer.run({ automergeConflictBranch: null })
+
+	const advanceCmds = execCalls.filter(c =>
+		c.includes('branch-here-') || c.includes('git checkout') ||
+		c.includes('git merge') || c.includes('git push origin '))
+	t.equal(advanceCmds.length, 0,
+		'should not attempt any branch-here advancement ' +
+		'or release-branch merges')
+
+	const skipped = infoMessages.find(m =>
+		m.includes('not a configured branch'))
+	t.ok(skipped,
+		'should log a skip message mentioning the ' +
+		'non-configured base')
+})


### PR DESCRIPTION
Fixes SpiderStrategies/impact#72734

When the Merge Bot fires on a closed PR whose base isn't a configured release branch (e.g. PR #72699 was merged into the feature branch `72162-geographic-...` instead of `main`), `BranchMaintainer` used to assume the base was a release branch and crash trying to advance `branch-here-<feature-branch>`. The result was a noisy "Merge Bot has failed" Slack alert and a red workflow run. `AutoMerger` already filtered this case correctly via `configReader`/`mergeOperations`; `BranchMaintainer` had no equivalent guard.

- Adds an early guard in `BranchMaintainer.run()` (after the merge-conflicts cleanup, before the decision tree) that skips maintenance when `base.ref` is neither a configured branch nor a `merge-forward-pr-*` branch. The merge-forward case is preserved because that's the legitimate conflict-resolution target.
- Extracts the commits-reached-main decision tree into a new `maintainBranchHere` method so `run()` stays under the screenful guideline. Moved lines are verbatim — `git blame` will still attribute them to their original authors.
- Adds a regression test in `test/branch-maintainer-test.js` reproducing the exact #72699 scenario (wrong-base PR) and asserts `run()` no-ops gracefully with no branch-here writes.

Made with [Cursor](https://cursor.com)