### PR TITLE
fixes #72756 IssueResolver failure prevents BranchMaintainer from running

### DIFF
--- a/src/automerger.js
+++ b/src/automerger.js
@@ -213,21 +213,38 @@ class AutoMerger {
 			this.core.info('All merges are complete')
 			await this.updateTargetBranches(mergedBranches)
 			await this.git.deleteBranch(this.prBranch)
+			await this.resolveReferencedIssues()
+		} else if (this.conflictBranch) {
+			this.generateMergeConflictNotice()
+		}
+		return allMergesPassed
+	}
 
-			// Issue #25 - Close any conflict issues referenced in the
-			// PR's commit messages (e.g., "Fixes #70345"). GitHub won't
-			// auto-close these because the PR merged into a merge-forward
-			// branch, not the default branch.
+	/**
+	 * Closes any issues referenced with closing keywords in the PR's
+	 * commit messages (e.g. "Fixes #70345"). GitHub won't auto-close
+	 * these because the PR merged into a merge-forward branch, not
+	 * the default branch (issue #25).
+	 *
+	 * #72756 - This is best-effort cleanup. If closing an issue fails
+	 * (transient GraphQL error, the issue is already closed, etc.) we
+	 * log the failure but don't rethrow. Letting this throw used to
+	 * abort the workflow before BranchMaintainer could run, leaving
+	 * branch-here pointers stranded and merge-forward branches orphaned.
+	 */
+	async resolveReferencedIssues() {
+		try {
 			await new IssueResolver({
 				prNumber: this.prNumber,
 				core: this.core,
 				shell: this.shell,
 				gh: this.gh
 			}).resolveIssues()
-		} else if (this.conflictBranch) {
-			this.generateMergeConflictNotice()
+		} catch (e) {
+			this.core.warning(
+				`IssueResolver failed (continuing anyway so` +
+				` branch maintenance still runs): ${e.message}`)
 		}
-		return allMergesPassed
 	}
 
 	/**

--- a/test/auto-merge-action-test.js
+++ b/test/auto-merge-action-test.js
@@ -379,6 +379,72 @@ tap.test('executeMerges', async t => {
 		)
 	})
 
+	t.test('IssueResolver failure does not abort executeMerges', async t => {
+		// #72756 - When `gh issue close` fails (e.g. transient
+		// GraphQL error), the exception was propagating out of
+		// AutoMerger and preventing BranchMaintainer from running.
+		// IssueResolver is best-effort cleanup — failures here must
+		// not abort the rest of the merge bot's work.
+		const core = mockCore({})
+		core.startGroup = () => {}
+		core.endGroup = () => {}
+
+		const shell = createMockShell(core, (cmd) => {
+			if (cmd.startsWith('gh issue close')) {
+				throw new Error(
+					'Command failed: gh issue close 71892\n' +
+					'GraphQL: Could not close the issue. (closeIssue)')
+			}
+			return ''
+		})
+
+		const git = createMockGit(shell)
+
+		const mockGh = {
+			github: {
+				context: {
+					serverUrl,
+					runId,
+					repo: { owner: 'sample', repo: 'repo' }
+				}
+			},
+			async fetchCommits() {
+				return {
+					data: [{
+						commit: {
+							message: 'fixes #71892 remaining test fixes' +
+								' related to H2 upgrade'
+						}
+					}]
+				}
+			}
+		}
+
+		class TestAction extends TestAutoMerger {
+			async merge({ branch }) {
+				return true
+			}
+			async updateTargetBranches() {}
+		}
+
+		const action = new TestAction({
+			prNumber: 71943,
+			prBranch: 'issue-71892-fix-more-h2-upgrade-tests',
+			core,
+			git,
+			shell,
+			gh: mockGh
+		})
+
+		const result = await action.executeMerges(['main'])
+
+		t.equal(result, true,
+			'executeMerges should still report success when ' +
+			'IssueResolver throws')
+		t.notOk(core.failedArg,
+			'should not call setFailed when only IssueResolver throws')
+	})
+
 	t.test('stops merging on first conflict', async t => {
 		const gitCalls = []
 		const core = mockCore({})


### PR DESCRIPTION
Fixes SpiderStrategies/impact#72756

When `IssueResolver.resolveIssues()` throws (e.g. a transient `gh issue close` GraphQL error like the one in [action run 24798818049](https://github.com/SpiderStrategies/impact/actions/runs/24798818049)), the exception used to propagate out of `AutoMerger.executeMerges` → `automerger.run()` → into the top-level try/catch in `src/merge-bot.js`, which meant `await maintainBranches(...)` was never called. The chain reached `main` correctly, but `branch-here-<release>` was never advanced and `merge-forward-pr-N-*` branches were never cleaned up — silent, persistent drift between `branch-here-<release>` and the release branch (real-world example: `branch-here-release-5.8.0` has been one commit behind `release-5.8.0` since 2026-04-22, exactly missing the H2 fix commit `c80e262fd32`).

- Extracts the `IssueResolver` call into a new `resolveReferencedIssues()` method on `AutoMerger` and wraps it in a try/catch that logs `core.warning` instead of rethrowing. `IssueResolver` is best-effort cleanup — failures must not abort the rest of the merge bot's work.
- Adds a regression test in `test/auto-merge-action-test.js` that reproduces the exact production failure (`gh issue close` throws with the same GraphQL message) and asserts `executeMerges` still returns `true` and doesn't call `setFailed`.

Made with [Cursor](https://cursor.com)