### PR TITLE
SpiderStrategies/impact#74377 Stop concurrent merge-bot runs from racing each other

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
 outputs:
   status:
-    description: 'Status: success or error'
+    description: 'Status: success or failure'
   status-message:
     description: 'Detailed status message for Slack notifications'
 runs:

--- a/manual-merge.sh
+++ b/manual-merge.sh
@@ -54,6 +54,13 @@ if ! command -v gh &> /dev/null; then
   exit 1
 fi
 
+# #72975 - Git requires the merge=ours driver in .gitattributes to be registered
+# per clone, or those attributes are a silent no-op and this script propagates
+# one branch's generated AI config up the chain. Repo-local so a recovery script
+# doesn't rewrite your global git config.
+log_info "Registering the 'ours' merge driver for this repo..."
+git config merge.ours.driver true
+
 # Step 1: Fetch all branches
 log_info "Fetching all branches..."
 git fetch --all --prune

--- a/src/automerger.js
+++ b/src/automerger.js
@@ -2,6 +2,7 @@ const { writeFile } = require('fs/promises')
 
 const { findIssueNumber } = require('gh-action-components')
 const IssueResolver = require('./issue-resolver')
+const pushWithRetry = require('./push-with-retry')
 const { UP_TO_DATE, MB_BRANCH_FAILED_PREFIX, MB_BRANCH_HERE_PREFIX, MB_BRANCH_FORWARD_PREFIX, ISSUE_COMMENT_FILENAME } = require('./constants')
 const {
 	extractOriginalPRNumber,
@@ -77,6 +78,7 @@ class AutoMerger {
 		this.statusMessage = null
 		this.lastSuccessfulMergeRef = null
 		this.lastSuccessfulBranch = null
+		this.failureMessage = null
 	}
 
 	async run() {
@@ -202,6 +204,9 @@ class AutoMerger {
 			} catch (e) {
 				this.core.error(e.message)
 				this.core.setFailed(e.message)
+				// #74377 - setFinalStatus reads this so a broken chain isn't
+				// reported as a success
+				this.failureMessage = e.message
 				break
 			} finally {
 				this.core.endGroup()
@@ -306,7 +311,6 @@ class AutoMerger {
 
 	/**
 	 * Updates a single target branch to match its merge-forward commit.
-	 * Attempts fast-forward first, falls back to merge commit if needed.
 	 *
 	 * @param {string} mergeForwardBranch - The merge-forward branch name
 	 *   (e.g., 'merge-forward-pr-123-release-5.8.0' or 'merge-forward-pr-123-main')
@@ -314,20 +318,48 @@ class AutoMerger {
 	 *   (e.g., 'release-5.8.0' or 'main')
 	 */
 	async updateTargetBranch(mergeForwardBranch, targetBranch) {
-		this.core.info(`Fast-forwarding ${targetBranch} to ${mergeForwardBranch}`)
-		await this.git.checkout(targetBranch)
+		this.core.info(`Updating ${targetBranch} from ${mergeForwardBranch}`)
 
+		await pushWithRetry({
+			shell: this.shell,
+			core: this.core,
+			branch: targetBranch,
+			merge: () => this.applyMergeForward(mergeForwardBranch, targetBranch)
+		})
+	}
+
+	/**
+	 * Merges the commit at the tip of [mergeForwardBranch] into the currently
+	 * checked out [targetBranch].
+	 *
+	 * Fast-forwards when the merge-forward branch was built on the target's
+	 * current tip, and falls back to a merge commit when a concurrent
+	 * merge-bot run moved the target on in the meantime (#74377).
+	 *
+	 * @param {string} mergeForwardBranch - The merge-forward branch name
+	 * @param {string} targetBranch - The branch already checked out
+	 */
+	async applyMergeForward(mergeForwardBranch, targetBranch) {
 		const mergeForwardCommit = await this.shell.exec(`git rev-parse origin/${mergeForwardBranch}`)
 
 		try {
 			await this.git.merge(mergeForwardCommit, '--ff-only')
 			this.core.info(`Fast-forwarded ${targetBranch}`)
+			return
 		} catch (e) {
 			this.core.info(`Fast-forward failed, creating merge commit for ${targetBranch}`)
-			await this.git.merge(mergeForwardCommit, '--no-ff')
 		}
 
-		await this.git.push(`origin ${targetBranch}`)
+		try {
+			await this.git.merge(mergeForwardCommit, '--no-ff')
+		} catch (e) {
+			// Retrying can't help - the same conflict recurs - so leave a
+			// clean tree behind and let the failure surface.
+			await this.shell.execQuietly('git merge --abort')
+			throw new Error(
+				`Could not merge ${mergeForwardBranch} into` +
+				` ${targetBranch}: ${e.message}`)
+		}
 	}
 
 	/**
@@ -359,16 +391,20 @@ class AutoMerger {
 		// https://github.com/SpiderStrategies/Scoreboard/actions/runs/19943416287/job/57186800013
 		options = '--no-commit --no-ff'
 	}) {
+		// #74377 - The runner's clone captured origin/* up to a minute ago and
+		// a concurrent run may have advanced the target since, so refresh
+		// before picking a base.
+		await this.shell.exec('git fetch origin')
+
 		// Create merge-forward based on the TARGET's branch-here, not the PR's progress.
 		// This ensures we merge FORWARD (few commits) not backward (thousands).
 		// The merge direction is: PR changes -> into -> target branch
 		const currentMergeForward = this.createMergeForwardBranchName(branch)
 		const targetRef = this.getBranchHereRef(branch)
-		await this.git.createBranch(currentMergeForward, `origin/${targetRef}`)
-		await this.git.push(`--force origin ${currentMergeForward}`)
-
-		// Switch to the merge-forward branch to perform the merge there
-		await this.git.checkout(currentMergeForward)
+		// #74377 - -B and --force so a re-run overwrites whatever a failed
+		// earlier attempt left behind, locally and on the remote.
+		await this.shell.exec(`git checkout -B ${currentMergeForward} origin/${targetRef}`)
+		await this.git.push(`--force --set-upstream origin ${currentMergeForward}`)
 
 		// Merge the PR's progress (lastSuccessfulMergeRef) INTO the target-based branch.
 		// This is the forward direction: few PR commits merged into the target.
@@ -379,7 +415,6 @@ class AutoMerger {
 
 		let mergeResult
 		try {
-			await this.git.pull() // Try to minimize chances of repo being out of date with origin (because of concurrent actions)
 			mergeResult = await this.git.merge(this.lastSuccessfulMergeRef, options)
 			this.core.info(mergeResult)
 		} catch (e) {

--- a/src/branch-maintainer.js
+++ b/src/branch-maintainer.js
@@ -5,6 +5,7 @@ const {
 	extractSourceFromMergeConflicts,
 	extractTargetFromMergeForward
 } = require('./branch-name-utils')
+const pushWithRetry = require('./push-with-retry')
 
 /**
  * Maintains branch-here pointers by updating them to the latest commit that
@@ -318,6 +319,9 @@ class BranchMaintainer {
 	 * The ancestry merge is critical: without it, branch-here would
 	 * have a merge commit that doesn't exist on the release branch,
 	 * causing them to diverge.
+	 *
+	 * Both pushes go through pushWithRetry because a concurrent
+	 * merge-bot run can advance either branch while we work (#74377).
 	 */
 	async advanceBranchHere({ releaseBranch, mergeRef, prNumber }) {
 		if (!(releaseBranch in this.config.branches)) {
@@ -330,21 +334,25 @@ class BranchMaintainer {
 		this.core.info(
 			`Advancing ${branchHere} with PR #${prNumber}`)
 
-		await this.shell.exec(`git checkout ${branchHere}`)
-		await this.shell.exec(`git pull`)
-		await this.shell.exec(
-			`git merge ${mergeRef} --no-ff ` +
-			`-m "Merge #${prNumber} into ${branchHere}"`)
-		await this.shell.exec(`git push origin ${branchHere}`)
+		await pushWithRetry({
+			shell: this.shell,
+			core: this.core,
+			branch: branchHere,
+			merge: () => this.shell.exec(
+				`git merge ${mergeRef} --no-ff ` +
+				`-m "Merge #${prNumber} into ${branchHere}"`)
+		})
 
 		// Issue #19 - Preserve ancestry
-		await this.shell.exec(`git checkout ${releaseBranch}`)
-		await this.shell.exec(`git pull`)
-		await this.shell.exec(
-			`git merge ${branchHere} --no-ff ` +
-			`-m "Merge #${prNumber} from ${branchHere}` +
-			` to ${releaseBranch}"`)
-		await this.shell.exec(`git push origin ${releaseBranch}`)
+		await pushWithRetry({
+			shell: this.shell,
+			core: this.core,
+			branch: releaseBranch,
+			merge: () => this.shell.exec(
+				`git merge ${branchHere} --no-ff ` +
+				`-m "Merge #${prNumber} from ${branchHere}` +
+				` to ${releaseBranch}"`)
+		})
 	}
 
 	/**
@@ -362,13 +370,15 @@ class BranchMaintainer {
 		this.core.info(
 			`Updating ${targetBranch} from ${mergeForwardBranch}`)
 
-		await this.shell.exec(`git checkout ${targetBranch}`)
-		await this.shell.exec(`git pull`)
-		await this.shell.exec(
-			`git merge origin/${mergeForwardBranch} --no-ff ` +
-			`-m "Merge ${mergeForwardBranch} into ` +
-			`${targetBranch}"`)
-		await this.shell.exec(`git push origin ${targetBranch}`)
+		await pushWithRetry({
+			shell: this.shell,
+			core: this.core,
+			branch: targetBranch,
+			merge: () => this.shell.exec(
+				`git merge origin/${mergeForwardBranch} --no-ff ` +
+				`-m "Merge ${mergeForwardBranch} into ` +
+				`${targetBranch}"`)
+		})
 	}
 
 }

--- a/src/merge-bot.js
+++ b/src/merge-bot.js
@@ -26,6 +26,12 @@ async function run() {
 		await git.configureIdentity('Spider Merge Bot',
 			'merge-bot@spiderstrategies.com')
 
+		// #72975 - git requires the merge=ours driver in .gitattributes to be
+		// registered per clone, or those attributes are a silent no-op.
+		// #74377 - Here rather than in the workflow, so release branches whose
+		// workflow file predates the rename to merge-bot.yml are covered too.
+		await shell.exec('git config merge.ours.driver true')
+
 		const automerger = await automerge({ config, shell, gh, git })
 		await maintainBranches({ config, shell, automerger })
 		setFinalStatus(automerger)
@@ -36,7 +42,9 @@ async function run() {
 		let statusMessage =
 			`Merge bot error: ${error.message} <${actionUrl}|Action Run>`
 		core.setFailed(error.message)
-		core.setOutput('status', 'error')
+		// #74377 - 'failure', not 'error': the workflow's Slack step filters
+		// on notify_when: 'warning,failure'.
+		core.setOutput('status', 'failure')
 		core.setOutput('status-message', statusMessage)
 	}
 }
@@ -113,12 +121,23 @@ function readConfig() {
  * The orchestrator owns these outputs to prevent phases from clobbering each other.
  *
  * Merge conflicts are expected behavior and count as success - an issue was
- * created for the developer to resolve. Only actual errors (exceptions) should
- * result in failure status.
+ * created for the developer to resolve. Anything else that stopped the chain
+ * reports failure, whether it surfaced as an exception or was caught and
+ * recorded by executeMerges.
  *
  * @param {AutoMerger} automerger The automerger instance
  */
 function setFinalStatus(automerger) {
+	// #74377 - executeMerges catches its own exceptions, so run() returns
+	// normally and the crash handler never sees a broken chain.
+	if (automerger.failureMessage) {
+		core.setOutput('status', 'failure')
+		core.setOutput('status-message',
+			`Merge chain failed: ${automerger.failureMessage}` +
+			` <${automerger.actionUrl}|Action Run>`)
+		return
+	}
+
 	// Both successful merges AND handled conflicts are "success"
 	// Conflicts are expected - an issue was created for the developer
 	core.setOutput('status', 'success')

--- a/src/push-with-retry.js
+++ b/src/push-with-retry.js
@@ -1,0 +1,51 @@
+/**
+ * How many times to build and push a shared branch before giving up. Three is
+ * ample for the roughly one-second window between a fetch and a push; a burst
+ * of merges long enough to exhaust it is a genuine failure worth surfacing.
+ */
+const PUSH_ATTEMPTS = 3
+
+/**
+ * Applies [merge] to the current tip of [branch] and pushes the result,
+ * retrying when a concurrent merge-bot run advances [branch] between our fetch
+ * and our push (#74377).
+ *
+ * Every attempt re-fetches and hard-resets to the remote tip, so a rejected
+ * push never leaves a half-applied merge behind. Resetting is safe at every
+ * call site because whatever is being merged lives on the remote - a
+ * merge-forward branch or the PR's head commit - so there is no local work to
+ * lose.
+ *
+ * @param {Object} options
+ * @param {Object} options.shell - Shell instance for executing commands
+ * @param {Object} options.core - The @actions/core module for logging
+ * @param {string} options.branch - The branch to advance and push
+ * @param {Function} options.merge - Performs the merge. Called once per
+ *   attempt, always with [branch] checked out at the remote tip.
+ * @param {number} [options.attempts=PUSH_ATTEMPTS] - How many times to try
+ * @returns {Promise<string>} Output of the push that succeeded
+ * @throws The final push rejection when every attempt is rejected
+ */
+async function pushWithRetry({ shell, core, branch, merge, attempts = PUSH_ATTEMPTS }) {
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		await shell.exec(`git checkout ${branch}`)
+		await shell.exec(`git fetch origin ${branch}`)
+		await shell.exec(`git reset --hard origin/${branch}`)
+
+		await merge()
+
+		try {
+			return await shell.exec(`git push origin ${branch}`)
+		} catch (e) {
+			if (attempt === attempts) {
+				throw e
+			}
+			core.info(`Push of ${branch} was rejected` +
+				` (attempt ${attempt} of ${attempts});` +
+				` retrying against its new tip`)
+		}
+	}
+}
+
+module.exports = pushWithRetry
+module.exports.PUSH_ATTEMPTS = PUSH_ATTEMPTS

--- a/test/auto-merge-action-test.js
+++ b/test/auto-merge-action-test.js
@@ -273,14 +273,19 @@ tap.test('executeMerges', async t => {
 		core.startGroup = () => {}
 		core.endGroup = () => {}
 
-		const shell = createMockShell(core, createGitShellBehavior({
+		const shellCalls = []
+		const gitShellBehavior = createGitShellBehavior({
 			mergeForwardBranches: {
 				'12345': [{ branch: 'release-5.8', sha: 'abc123' }]
 			},
 			revParse: {
 				'origin/merge-forward-pr-12345-release-5.8': 'commit-sha-release-5.8'
 			}
-		}))
+		})
+		const shell = createMockShell(core, (cmd) => {
+			shellCalls.push(cmd)
+			return gitShellBehavior(cmd)
+		})
 
 		const git = createMockGit(shell, { callTracker: gitCalls })
 
@@ -306,11 +311,15 @@ tap.test('executeMerges', async t => {
 		const result = await action.executeMerges(['release-5.8', 'main'])
 
 		t.equal(result, true, 'should return true when all merges succeed')
-		t.ok(gitCalls.filter(c => c === 'checkout:release-5.8').length >= 2,
-			'should checkout release-5.8 for merging AND for updating')
+		t.ok(gitCalls.includes('checkout:release-5.8'),
+			'should checkout release-5.8 to merge into it')
+		t.ok(shellCalls.includes('git checkout release-5.8'),
+			'should check release-5.8 out again to update it')
+		t.ok(shellCalls.includes('git fetch origin release-5.8'),
+			'should refresh release-5.8 before merging onto its tip')
 		t.ok(gitCalls.find(c => c.includes('merge:commit-sha-release-5.8:--ff-only')),
 			'should fast-forward release-5.8 to its merge-forward commit')
-		t.ok(gitCalls.find(c => c.includes('push:origin release-5.8')),
+		t.ok(shellCalls.includes('git push origin release-5.8'),
 			'should push updated release-5.8')
 		t.notOk(gitCalls.find(c => c.includes('merge:') && c.includes('main')),
 			'should not update main (terminal branch)')
@@ -508,7 +517,80 @@ tap.test('executeMerges', async t => {
 
 		t.equal(result, false, 'should return false when exception occurs')
 		t.ok(core.failedArg, 'should call setFailed when exception occurs')
+		// #74377 - setFinalStatus reads this to avoid reporting success
+		t.match(action.failureMessage, /Git merge failed/,
+			'should record why the chain broke')
 		t.equal(gitCalls.filter(c => c.startsWith('checkout')).length, 2, 'should stop after exception')
+	})
+})
+
+tap.test('applyMergeForward', async t => {
+
+	t.test('fast-forwards when the target has not moved', async t => {
+		const gitCalls = []
+		const core = mockCore({})
+		const shell = createMockShell(core, createGitShellBehavior({
+			revParse: { 'origin/merge-forward-pr-123-main': 'forwardCommit' }
+		}))
+		const git = createMockGit(shell, { callTracker: gitCalls })
+
+		const action = new TestAutoMerger({ core, git, shell })
+
+		await action.applyMergeForward('merge-forward-pr-123-main', 'main')
+
+		t.ok(gitCalls.includes('merge:forwardCommit:--ff-only'),
+			'should fast-forward')
+		t.notOk(gitCalls.find(c => c.includes('--no-ff')),
+			'should not create a merge commit when a fast-forward works')
+	})
+
+	t.test('falls back to a merge commit when a concurrent run moved the target', async t => {
+		const gitCalls = []
+		const core = mockCore({})
+		const shell = createMockShell(core, createGitShellBehavior({
+			revParse: { 'origin/merge-forward-pr-123-main': 'forwardCommit' }
+		}))
+		const git = createMockGit(shell, { callTracker: gitCalls })
+		git.merge = async (ref, options) => {
+			gitCalls.push(`merge:${ref}:${options}`)
+			if (options === '--ff-only') {
+				throw new Error('fatal: Not possible to fast-forward, aborting.')
+			}
+			return ''
+		}
+
+		const action = new TestAutoMerger({ core, git, shell })
+
+		await action.applyMergeForward('merge-forward-pr-123-main', 'main')
+
+		t.ok(gitCalls.includes('merge:forwardCommit:--no-ff'),
+			'should create a merge commit instead')
+	})
+
+	t.test('aborts and reports when the fallback merge conflicts', async t => {
+		// #74377 - Aborting rather than retrying, because the same conflict
+		// recurs on every attempt.
+		const shellCalls = []
+		const core = mockCore({})
+		const gitShellBehavior = createGitShellBehavior({
+			revParse: { 'origin/merge-forward-pr-123-main': 'forwardCommit' }
+		})
+		const shell = createMockShell(core, (cmd) => {
+			shellCalls.push(cmd)
+			return gitShellBehavior(cmd)
+		})
+		const git = createMockGit(shell)
+		git.merge = async () => { throw new Error('CONFLICT (content)') }
+
+		const action = new TestAutoMerger({ core, git, shell })
+
+		await t.rejects(
+			action.applyMergeForward('merge-forward-pr-123-main', 'main'),
+			/Could not merge merge-forward-pr-123-main into main: CONFLICT/,
+			'should name both branches and keep git\'s message')
+
+		t.ok(shellCalls.includes('git merge --abort'),
+			'should leave a clean tree behind')
 	})
 })
 
@@ -958,6 +1040,11 @@ tap.test('handleConflicts', async t => {
 			if (cmd === 'git rev-parse HEAD') {
 				return 'mergeCommit-' + Math.random().toString(36).substring(7)
 			}
+			const created = cmd.match(/^git checkout -B (\S+) /)
+			if (created) {
+				createdBranches.add(created[1])
+				branchCreationOrder.push(created[1])
+			}
 			return ''
 		})
 
@@ -965,13 +1052,6 @@ tap.test('handleConflicts', async t => {
 		git.merge = async (sha, options) => {
 			// All merges succeed
 			return 'Merge made by strategy'
-		}
-		git.createBranch = async (branchName, ref) => {
-			if (createdBranches.has(branchName)) {
-				throw new Error(`fatal: a branch named '${branchName}' already exists`)
-			}
-			createdBranches.add(branchName)
-			branchCreationOrder.push(branchName)
 		}
 
 		const mockGh = {
@@ -1490,9 +1570,13 @@ tap.test('originalPRNumber propagates original PR through conflict resolution ch
 tap.test('merge', async t => {
 	t.test('handles already merged case', async t => {
 		const gitCalls = []
+		const shellCalls = []
 		const core = mockCore({})
 
-		const shell = createMockShell(core)
+		const shell = createMockShell(core, (cmd) => {
+			shellCalls.push(cmd)
+			return ''
+		})
 		const git = createMockGit(shell, { callTracker: gitCalls })
 		// Override merge to return "Already up to date"
 		git.merge = async (sha, options) => {
@@ -1517,7 +1601,8 @@ tap.test('merge', async t => {
 		const result = await action.merge({branch: 'release-5.8'})
 
 		t.equal(result, true, 'should return true even when already merged')
-		t.ok(gitCalls.find(c => c.includes('pull')), 'should pull before merging')
+		t.ok(shellCalls.includes('git fetch origin'),
+			'should refresh remote-tracking refs before picking a base')
 		// Should merge lastSuccessfulMergeRef (PR's progress), not pullRequest.head.sha
 		t.ok(gitCalls.find(c => c.includes('merge:originalCommit')), 'should merge lastSuccessfulMergeRef (forward direction)')
 		// When already merged, no commit or branch creation should happen
@@ -1585,7 +1670,9 @@ tap.test('merge', async t => {
 		t.equal(result, true, 'should return true on success')
 		t.ok(commitCalled, 'should create commit when merge successful')
 		t.equal(action.lastSuccessfulMergeRef, 'newMergeCommit789', 'should update lastSuccessfulMergeRef to new merge commit')
-		t.ok(gitCommands.includes('createBranch'), 'should create merge-forward branch')
+		t.ok(shellCommands.includes(
+			'git checkout -B merge-forward-pr-789-release-5.8 origin/branch-here-release-5.8'),
+			'should create merge-forward branch from the target\'s branch-here')
 		t.ok(gitCommands.find(c => c.startsWith('push:')), 'should push merge-forward branch')
 	})
 

--- a/test/merge-bot-test.js
+++ b/test/merge-bot-test.js
@@ -67,7 +67,9 @@ tap.test('maintainBranchHerePointers', async t => {
 		}
 	})
 
-	t.test('sets error outputs when automerge throws', async t => {
+	t.test('sets failure outputs when automerge throws', async t => {
+		// #74377 - 'failure' is what the workflow's notify_when matches;
+		// the old 'error' value matched nothing.
 		const testState = createTestEnvironment({
 			baseBranch: 'release-5.6.0',
 			config: {
@@ -83,7 +85,7 @@ tap.test('maintainBranchHerePointers', async t => {
 		try {
 			await runMergeBot()
 
-			t.equal(testState.outputs.status, 'error')
+			t.equal(testState.outputs.status, 'failure')
 			t.match(
 				testState.outputs['status-message'],
 				/git merge failed/)
@@ -93,6 +95,57 @@ tap.test('maintainBranchHerePointers', async t => {
 			t.match(
 				testState.failedMessage,
 				/git merge failed/)
+		} finally {
+			restore()
+		}
+	})
+
+	t.test('sets failure outputs when the merge chain breaks without throwing', async t => {
+		// #74377 - executeMerges catches its own exceptions, so this never
+		// reaches the crash handler tested above.
+		const testState = createTestEnvironment({
+			baseBranch: 'release-5.6.0',
+			config: {
+				...baseConfig,
+				mergeTargets: ['release-5.7.0', 'main']
+			}
+		})
+		testState.automergeFailureMessage =
+			'Command failed: git push --set-upstream origin' +
+			' merge-forward-pr-74333-main'
+
+		const restore = useTestActions(testState)
+
+		try {
+			await runMergeBot()
+
+			t.equal(testState.outputs.status, 'failure',
+				'should not stamp success over a broken chain')
+			t.match(
+				testState.outputs['status-message'],
+				/merge-forward-pr-74333-main/,
+				'should say what broke')
+		} finally {
+			restore()
+		}
+	})
+
+	t.test('registers the ours merge driver', async t => {
+		// #72975 - merge=ours in .gitattributes is a silent no-op unless the
+		// driver is registered in this clone.
+		const testState = createTestEnvironment({
+			baseBranch: 'release-5.7.0',
+			config: { ...baseConfig, mergeTargets: ['main'] }
+		})
+
+		const restore = useTestActions(testState)
+
+		try {
+			await runMergeBot()
+
+			t.ok(testState.shellCommands.includes(
+				'git config merge.ours.driver true'),
+				'should register the ours merge driver before merging')
 		} finally {
 			restore()
 		}

--- a/test/push-with-retry-test.js
+++ b/test/push-with-retry-test.js
@@ -1,0 +1,121 @@
+const tap = require('tap')
+const { mockCore } = require('gh-action-components')
+
+const pushWithRetry = require('../src/push-with-retry')
+const { createMockShell } = require('./test-helpers')
+
+/**
+ * Builds a shell whose `git push` fails for the first [rejections] calls,
+ * recording every command so tests can assert the retry sequence.
+ */
+function createRejectingShell(core, rejections) {
+	const commands = []
+	let pushes = 0
+
+	const shell = createMockShell(core, (cmd) => {
+		commands.push(cmd)
+		if (cmd.startsWith('git push')) {
+			pushes++
+			if (pushes <= rejections) {
+				throw new Error(`! [rejected] (non-fast-forward)`)
+			}
+			return 'pushed'
+		}
+		return ''
+	})
+
+	return { shell, commands }
+}
+
+tap.test('pushWithRetry', async t => {
+
+	t.test('fetches and resets before merging so the merge lands on the remote tip', async t => {
+		const core = mockCore({})
+		const { shell, commands } = createRejectingShell(core, 0)
+
+		await pushWithRetry({
+			shell,
+			core,
+			branch: 'main',
+			merge: async () => { commands.push('<merge>') }
+		})
+
+		t.same(commands, [
+			'git checkout main',
+			'git fetch origin main',
+			'git reset --hard origin/main',
+			'<merge>',
+			'git push origin main'
+		], 'should refresh main before merging, then push')
+	})
+
+	t.test('returns the push output', async t => {
+		const core = mockCore({})
+		const { shell } = createRejectingShell(core, 0)
+
+		const result = await pushWithRetry({
+			shell,
+			core,
+			branch: 'main',
+			merge: async () => {}
+		})
+
+		t.equal(result, 'pushed', 'should return the output of the push')
+	})
+
+	t.test('rebuilds against the new tip when a concurrent run wins the push', async t => {
+		const core = mockCore({})
+		const { shell, commands } = createRejectingShell(core, 1)
+
+		await pushWithRetry({
+			shell,
+			core,
+			branch: 'main',
+			merge: async () => { commands.push('<merge>') }
+		})
+
+		t.equal(commands.filter(c => c === 'git push origin main').length, 2,
+			'should push twice - once rejected, once accepted')
+		t.equal(commands.filter(c => c === 'git fetch origin main').length, 2,
+			'should re-fetch before the retry rather than reusing the stale tip')
+		t.equal(commands.filter(c => c === 'git reset --hard origin/main').length, 2,
+			'should discard the rejected attempt instead of merging on top of it')
+		t.equal(commands.filter(c => c === '<merge>').length, 2,
+			'should redo the merge against the new tip')
+	})
+
+	t.test('gives up after the configured number of attempts', async t => {
+		const core = mockCore({})
+		const { shell, commands } = createRejectingShell(core, 5)
+
+		await t.rejects(
+			pushWithRetry({
+				shell,
+				core,
+				branch: 'main',
+				merge: async () => {},
+				attempts: 3
+			}),
+			/non-fast-forward/,
+			'should rethrow the push rejection once attempts run out')
+
+		t.equal(commands.filter(c => c === 'git push origin main').length, 3,
+			'should stop after 3 attempts rather than retrying forever')
+	})
+
+	t.test('defaults to PUSH_ATTEMPTS attempts', async t => {
+		const core = mockCore({})
+		const { shell, commands } = createRejectingShell(core, 99)
+
+		await t.rejects(pushWithRetry({
+			shell,
+			core,
+			branch: 'main',
+			merge: async () => {}
+		}))
+
+		t.equal(commands.filter(c => c === 'git push origin main').length,
+			pushWithRetry.PUSH_ATTEMPTS,
+			'should use PUSH_ATTEMPTS when no attempts option is given')
+	})
+})

--- a/test/real-git-test.js
+++ b/test/real-git-test.js
@@ -54,7 +54,7 @@ async function createTestRepo() {
 	execSync('git init --bare', { cwd: originDir })
 
 	// Initialize repo
-	git('init')
+	git('init -b master')
 	git('config user.email "test@test.com"')
 	git('config user.name "Test"')
 	git(`remote add origin ${originDir}`)
@@ -279,7 +279,6 @@ tap.test('Phase 1b: Multi-step chain (merges through release, then conflicts at 
 	// Track what happens
 	let conflictsDetected = false
 	let conflictBranch = null
-	const createdBranches = []
 
 	const AutoMerger = require('../src/automerger')
 	class TestAutoMerger extends AutoMerger {
@@ -289,13 +288,6 @@ tap.test('Phase 1b: Multi-step chain (merges through release, then conflicts at 
 			this.conflictBranch = branch
 			await this.git.reset(branch, '--hard')
 		}
-	}
-
-	// Override createBranch to track branch creation
-	const originalCreateBranch = gitHelper.createBranch.bind(gitHelper)
-	gitHelper.createBranch = async (name, ref) => {
-		createdBranches.push(name)
-		return originalCreateBranch(name, ref)
 	}
 
 	// Override commit to use simple git commit (avoids .commitmsg file issues)
@@ -342,12 +334,11 @@ tap.test('Phase 1b: Multi-step chain (merges through release, then conflicts at 
 	t.ok(conflictsDetected, 'conflict should be detected at main')
 	t.equal(conflictBranch, 'main', 'conflict should be at main, not release-5.8.0')
 
-	// Verify merge-forward branch was created for successful step
-	t.ok(createdBranches.includes('merge-forward-pr-999-release-5.8.0'),
+	// Verify merge-forward branches reached the remote for both steps
+	const mergeForwardBranches = git("ls-remote --heads origin 'merge-forward-pr-999-*'")
+	t.match(mergeForwardBranches, /merge-forward-pr-999-release-5\.8\.0/,
 		'should create merge-forward branch for successful release-5.8.0 merge')
-
-	// Verify merge-forward branch was created for conflict step
-	t.ok(createdBranches.includes('merge-forward-pr-999-main'),
+	t.match(mergeForwardBranches, /merge-forward-pr-999-main/,
 		'should create merge-forward branch for main (before conflict detected)')
 })
 
@@ -2432,4 +2423,182 @@ tap.test('Issue #27: AutoMerger resumes chain when conflict resolution PR merges
 	t.same(executedTargets, ['main'],
 		'should resume chain targeting only main ' +
 		'(remaining after release-5.8.0)')
+})
+
+/**
+ * Builds the repo layout the #74377 tests share: release-5.8.0 with its
+ * branch-here pointer, main, and one PR commit on release-5.8.0 that adds a
+ * file main doesn't have (so the forward merge never conflicts on content).
+ *
+ * @returns {Promise<string>} the PR commit SHA
+ */
+async function setupForwardMergeRepo({ repoDir, git }) {
+	await writeFile(join(repoDir, 'test.txt'), 'Original\n')
+	git('add test.txt')
+	git('commit -m "Initial"')
+
+	git('checkout -b release-5.8.0')
+	git('push origin release-5.8.0')
+	git('branch branch-here-release-5.8.0')
+	git('push origin branch-here-release-5.8.0')
+
+	git('checkout -b main')
+	git('push origin main')
+
+	git('checkout release-5.8.0')
+	await writeFile(join(repoDir, 'pr-feature.txt'), 'PR feature\n')
+	git('add pr-feature.txt')
+	git('commit -m "PR feature"')
+	const prCommit = git('rev-parse HEAD')
+	git('push origin release-5.8.0')
+
+	return prCommit
+}
+
+/**
+ * Builds an AutoMerger wired to real git in [repoDir], merging [prCommit]
+ * from release-5.8.0 towards main.
+ */
+function createForwardMergeAction({ repoDir, prCommit, prNumber }) {
+	const { Shell, Git } = require('gh-action-components')
+	const core = mockCore({})
+	const shell = new Shell(core)
+	shell.exec = async (cmd) => {
+		if (cmd.startsWith('gh ')) return ''
+		return execSync(cmd, { cwd: repoDir, encoding: 'utf-8' }).trim()
+	}
+	const gitHelper = new Git(shell)
+
+	// The real commit() writes .commitmsg into cwd, which isn't repoDir here
+	gitHelper.commit = async (message, author) => {
+		const authorStr = `${author.name} <${author.email}>`
+		const escapedMsg = message.replace(/`/g, "'").replace(/"/g, '\\"')
+		return shell.exec(`git commit -m "${escapedMsg}" --author="${authorStr}"`)
+	}
+
+	const AutoMerger = require('../src/automerger')
+	const action = new AutoMerger({
+		pullRequest: { merged: true, head: { sha: prCommit }, merge_commit_sha: prCommit },
+		repository: { owner: 'test', name: 'repo' },
+		config: {
+			branches: { 'release-5.8.0': {}, 'main': {} },
+			mergeTargets: ['main']
+		},
+		prNumber,
+		prAuthor: 'testuser',
+		prTitle: 'Add feature',
+		prBranch: 'feature-branch',
+		baseBranch: 'release-5.8.0',
+		prCommitSha: prCommit,
+		core,
+		shell,
+		gh: {
+			github: {
+				context: {
+					serverUrl: 'https://github.com',
+					runId: 1,
+					repo: { owner: 'test', repo: 'repo' }
+				}
+			},
+			async createIssue() {
+				return { data: { number: 999, html_url: 'http://example.com' } }
+			},
+			async fetchCommits() {
+				return {
+					data: [{
+						commit: {
+							author: { name: 'Test', email: 'test@test.com' },
+							message: 'Test commit'
+						}
+					}]
+				}
+			}
+		},
+		git: gitHelper
+	})
+
+	action.terminalBranch = 'main'
+	action.lastSuccessfulBranch = 'release-5.8.0'
+	action.lastSuccessfulMergeRef = prCommit
+
+	return action
+}
+
+tap.test('#74377: a concurrent run advancing main does not break the target update', async t => {
+	// Reproduces attempt 1 of actions/runs/31710892479: another merge-bot run
+	// pushed main between this run's clone and its target-branch push.
+	const { repoDir, originDir, git } = await createTestRepo()
+
+	t.teardown(async () => {
+		await cleanupTestRepo(repoDir, originDir)
+	})
+
+	const prCommit = await setupForwardMergeRepo({ repoDir, git })
+
+	// A separate clone stands in for the other merge-bot run. It has to be a
+	// separate clone: pushing from repoDir would also refresh this run's refs
+	// and hide the staleness that causes the bug.
+	const otherDir = await mkdtemp(join(tmpdir(), 'merge-bot-other-'))
+	t.teardown(async () => {
+		await rm(otherDir, { recursive: true, force: true })
+	})
+	execSync(`git clone --branch main ${originDir} ${otherDir}`, { encoding: 'utf-8' })
+	const otherGit = createGitHelper(otherDir)
+	otherGit('config user.email "other@test.com"')
+	otherGit('config user.name "Other"')
+
+	const action = createForwardMergeAction({ repoDir, prCommit, prNumber: 74280 })
+
+	// Push to main after the forward merge is built but before the target
+	// update runs - the window the race lands in
+	const updateTargetBranches = action.updateTargetBranches.bind(action)
+	action.updateTargetBranches = async (branches) => {
+		await writeFile(join(otherDir, 'concurrent.txt'), 'From the other run\n')
+		otherGit('add concurrent.txt')
+		otherGit('commit -m "Concurrent run"')
+		otherGit('push origin main')
+		return updateTargetBranches(branches)
+	}
+
+	const result = await action.executeMerges(['main'])
+	t.equal(result, true, 'the merge chain should complete')
+
+	git('fetch origin')
+	const mainFiles = git('ls-tree --name-only origin/main').split('\n')
+	t.ok(mainFiles.includes('pr-feature.txt'),
+		'main should have the PR change')
+	t.ok(mainFiles.includes('concurrent.txt'),
+		'main should still have the concurrent run\'s change')
+})
+
+tap.test('#74377: a leftover merge-forward branch does not block a re-run', async t => {
+	// Reproduces attempt 2 of actions/runs/31734477096: attempt 1 died at the
+	// main push and left merge-forward-pr-<n>-main behind on the remote.
+	const { repoDir, originDir, git } = await createTestRepo()
+
+	t.teardown(async () => {
+		await cleanupTestRepo(repoDir, originDir)
+	})
+
+	const prCommit = await setupForwardMergeRepo({ repoDir, git })
+
+	// The debris from the failed first attempt: a merge-forward branch on the
+	// remote that is ahead of the base this run will branch from
+	git('checkout -b merge-forward-pr-74333-main origin/main')
+	await writeFile(join(repoDir, 'leftover.txt'), 'From the failed attempt\n')
+	git('add leftover.txt')
+	git('commit -m "Leftover from attempt 1"')
+	git('push origin merge-forward-pr-74333-main')
+	git('checkout release-5.8.0')
+	git('branch -D merge-forward-pr-74333-main')
+
+	const action = createForwardMergeAction({ repoDir, prCommit, prNumber: 74333 })
+
+	const result = await action.executeMerges(['main'])
+	t.equal(result, true, 'the merge chain should complete')
+
+	git('fetch origin')
+	const mainFiles = git('ls-tree --name-only origin/main').split('\n')
+	t.ok(mainFiles.includes('pr-feature.txt'),
+		'main should have the PR change')
 })

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -249,6 +249,7 @@ function createTestEnvironment({
 }) {
 	const coreInfoMessages = []
 	const outputs = {}
+	const shellCommands = []
 	const testState = {
 		automergeRan: false,
 		cleanupMergeConflictsBranchCalled: false,
@@ -256,7 +257,8 @@ function createTestEnvironment({
 		conflictBranch: undefined,
 		config,
 		coreInfoMessages,
-		outputs
+		outputs,
+		shellCommands
 	}
 
 	// Setup github context
@@ -300,6 +302,7 @@ function createMergeBotTestActions(testState) {
 			}
 			this.terminalBranch = testState.terminalBranch
 			this.conflictBranch = testState.conflictBranch
+			this.failureMessage = testState.automergeFailureMessage
 		}
 	}
 
@@ -352,8 +355,11 @@ function useTestActions(testState) {
 		constructor(core) {
 			this.core = core
 		}
-		async exec() { return '' }
-		async execQuietly() { return '' }
+		async exec(cmd) {
+			testState.shellCommands.push(cmd)
+			return ''
+		}
+		async execQuietly(cmd) { return this.exec(cmd) }
 	}
 
 	ghActionComponents.GitHubClient = class MockGitHubClient {


### PR DESCRIPTION
Fixes the concurrency race in [SpiderStrategies/impact#74377](https://github.com/SpiderStrategies/impact/issues/74377) (milestone 5.8.1, high priority).

## ⚠️ Merging this is an immediate production deploy

Both Impact workflow files pin `pal-repo-name: SpiderStrategies/merge-bot@main`, and `build-dist.yml` commits `dist/` on every push to `main`. There's no staging and no rollback. Worth merging when someone can watch the next few forward merges, with `manual-merge.sh` on hand.

## The race

Each run built its `merge-forward-pr-<n>-<target>` branch from the `origin/*` refs its clone captured, and never refreshed them. Confirmed in [run 31710892479](https://github.com/SpiderStrategies/impact/actions/runs/31710892479) attempt 1:

```
git checkout -b merge-forward-pr-74280-main origin/main     <- origin/main = 9e8c62b6527 (stale)
git pull
    9e8c62b6527..d6c16e5b929  main -> origin/main            <- refresh, one step too late
git merge 4228d320c --no-commit --no-ff                      <- merged onto the stale base
...
git checkout main                                            <- local main still 9e8c62b6527
git merge 814a2886f61 --ff-only   -> "Fast-forwarded main"    <- succeeds against the wrong base
git push origin main              -> ! [rejected] (non-fast-forward)
```

Two separate problems in one sequence. The refresh happened *after* the base was chosen, so it couldn't help. And `updateTargetBranch()` merged and pushed with no refresh in between — so `--ff-only` *succeeded* against a stale local `main`, meaning the existing `--no-ff` fallback never fired and the wrong state reached the push.

Removing `filter: blob:none` (needed for #74311) grew clone time ~17s → ~50s, which is why this started firing. But the window in that first failure was **1.3 seconds**, so refreshing alone isn't enough — the push has to be retried.

## Changes

**`merge()`** fetches before picking a base, and uses `checkout -B` + `push --force --set-upstream` in place of `createBranch()` + a second force push. That second part fixes re-run recovery: `Git.createBranch()` pushes unforced, so attempt 1's leftover branch killed attempt 2 before it started ([run 31734477096](https://github.com/SpiderStrategies/impact/actions/runs/31734477096)). Left `gh-action-components` alone so this doesn't drag a second repo into the deploy.

**New `src/push-with-retry.js`** — `checkout → fetch → reset --hard → merge → push`, retrying on rejection (3 attempts). The hard reset is the load-bearing detail: a rejected push never leaves a half-applied merge for the next attempt to stack on. Safe at every call site because whatever is being merged already lives on the remote.

**Used at all four racing pushes**, not just the one that failed: `updateTargetBranch`, `advanceBranchHere` (both pushes), `mergeToTerminalBranch`. The `BranchMaintainer` ones already pulled, so their window is ~1s rather than ~50s — but it's the same defect, and the four pushes in the 2026-08-13 logs succeeded on luck.

**`applyMergeForward`** holds the `--ff-only`/`--no-ff` pair, which now runs against a fresh tip so it actually means something. A conflicting fallback merge aborts and reports both branch names — retrying can't help there.

**Slack.** Two silent paths, not one:

- The crash handler set `status: 'error'`, which matches no entry in `notify_when: 'warning,failure'`. Now `'failure'`.
- Worse, [run 31734477096](https://github.com/SpiderStrategies/impact/actions/runs/31734477096) passed **`status: success`** to Slack over a red job — `executeMerges` catches its own exceptions, so `run()` returned normally, the crash handler never fired, and `setFinalStatus` stamped success. Fixing only `error` → `failure` would have left that run silent.

The second is #74311's defect 4, included deliberately — see below.

## No Impact yaml change needed, and why that matters

`.gitattributes` marks the generated AI config `merge=ours`, and git requires the driver registered **per clone**. Impact has **two live merge-bot workflow files**: `merge-bot.yml` (5.8.1, main) registers it; `spider-merge-bot.yml` (release-5.8.0, release-5.7.2, pre-rename 724a485242d) does not. Both are live — `spider-merge-bot.yml` has 2954 runs and last fired 2026-08-17 for the `release-5.8.0` PR `issue-74091-upgrade-log4j-to-2255`. So `merge=ours` has been inert on that branch line, and `release-5.7.2`'s `.gitattributes` even says "see merge-bot.yml", a file that doesn't exist there.

Registering the driver **in the action** covers every branch the moment this merges. The yaml alternative is worse — I dry-ran it rather than guessing:

```
$ git merge-tree --write-tree --name-only origin/branch-here-release-5.8.1 <test-commit>
.github/workflows/merge-bot.yml
Auto-merging .github/workflows/merge-bot.yml
CONFLICT (content): Merge conflict in .github/workflows/merge-bot.yml
```

Git follows the rename and tries to apply the edit to `merge-bot.yml`, which already has that line. The same dry run against unmodified `release-5.8.0` is clean, so the edit would be the sole cause of a merge-conflict issue — to add a line already present on the other side.

The `- run: git config --global merge.ours.driver true` step in `merge-bot.yml` is now redundant but harmless; removing it is a yaml change on two branches for no gain. `manual-merge.sh` registers it too (repo-local, so a recovery script doesn't rewrite your global config).

## Testing

`npm test` — 7 files green. Coverage **97.07 / 81.73 / 100 / 97.05** (gates 75/70/75/75), up from 93.93/78.3/100/93.89.

Both regression tests were written red-first and confirmed to fail for the right reason before the fix — `git push origin main` rejected, and `executeMerges` returning false on the leftover branch:

- **`real-git-test.js`** — concurrent run advancing `main` (uses a second clone, since pushing from the run's own clone would refresh its refs and hide the staleness); leftover merge-forward branch blocking a re-run.
- **`push-with-retry-test.js`** (new) — command ordering, retry after one rejection, giving up after `attempts`, the default.
- **`applyMergeForward`** — fast-forward, `--no-ff` fallback, abort-and-report on conflict.
- **`merge-bot-test.js`** — crash → `failure`; caught chain break → `failure` not `success`; merge-driver registration.

`manual-merge.sh` has no harness — verify by hand in a scratch clone with divergent AI config. `merge-bot-test.txt` is already left divergent between `main` and `release-5.8.1` for this.

### Two things to look at in review

**Test harness fix, unrequested but unavoidable.** `test/real-git-test.js` did `git('init')` then `git checkout -b main`, which fails wherever `init.defaultBranch = main` — **18 of 19 real-git tests died before reaching an assertion**. Pinned to `git init -b master`. Nothing was testable until this landed.

**Three existing assertions had to move.** They spied on `git.createBranch` / `git.pull` / `git.checkout` — calls that intentionally no longer exist. Moved to observing the outcome where possible (Phase 1b now checks the branches reached the remote via `ls-remote`, rather than trusting a method spy) and the shell commands otherwise. No assertion was weakened or deleted to make things pass.

## Deliberate overlap with #74311

`setFinalStatus` stamping `success` over a failed chain is #74311's defect 4. Included here because this issue's claim that every crash is Slack-silent is only half-fixed without it. #74311 keeps its other three defects, including the `BranchMaintainer` `allMergesPassed` threading.

Rebased onto current `main`, which picked up #72756 and #72734 — both touch the same files. Clean rebase, and I checked the merged regions rather than trusting it: `executeMerges` carries both `resolveReferencedIssues()` and `failureMessage`, and `BranchMaintainer` has the new `run()`/`maintainBranchHere()` split plus all three `pushWithRetry` sites.

## Out of scope

- #74311's remaining silent-failure handling (discarded exception in `merge()`, `handleConflicts()`'s empty-conflict-list path, `BranchMaintainer` inferring success from `!conflictBranch`).
- A workflow `concurrency:` group — the issue explains why (GitHub keeps one pending run per group and cancels the previous, so a forward merge silently never happens).
- Pinning `pal-repo-name` to a tag/SHA, and reconciling the two Impact workflow files.
- `action.yml` still uses `node20`; the runner already warns it's deprecated. Unrelated — worth its own issue.

## Note on the commit reference

The commit uses the plain `SpiderStrategies/impact#74377` form, without a closing keyword, matching the most recent cross-repo commit (3aa6bb7). So merging won't auto-close the Impact issue — it should stay open until the forward merges are verified on the real runner post-deploy. Say the word if you'd rather it close on merge.
